### PR TITLE
Change payment status to input before processing form

### DIFF
--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -19,6 +19,8 @@ class DummyProvider(BasicProvider):
     '''
 
     def get_form(self, data=None):
+        if self.payment.status == 'waiting':
+            self.payment.change_status('input')
         form = DummyForm(data=data, hidden_inputs=False, provider=self,
                          payment=self.payment)
         if form.is_valid():

--- a/payments/dummy/forms.py
+++ b/payments/dummy/forms.py
@@ -21,7 +21,7 @@ class DummyForm(PaymentForm):
 
     def clean(self):
         cleaned_data = super(DummyForm, self).clean()
-        gateway_response = cleaned_data['gateway_response']
+        gateway_response = cleaned_data.get('gateway_response')
         verification_result = cleaned_data.get('verification_result')
         if gateway_response == '3ds-redirect' and not verification_result:
             raise forms.ValidationError(

--- a/payments/dummy/tests.py
+++ b/payments/dummy/tests.py
@@ -147,3 +147,8 @@ class TestDummy3DSProvider(TestCase):
         }
         with self.assertRaises(PaymentError):
             provider.get_form(data)
+
+    def test_provider_switches_payment_status_on_get_form(self):
+        provider = DummyProvider(self.payment)
+        form = provider.get_form(data={})
+        self.assertEqual(self.payment.status, 'input')


### PR DESCRIPTION
Similar to `CyberSourceProvider`, the `Dummy3DSProvider` should switch payment status from `waiting` to `input` before form initialization.