### PR TITLE
Fixed install for sofort.com

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE README.md
-recursive-include payments *.html *.js *.wsdl *.xsd
+recursive-include payments *.html *.js *.wsdl *.xsd *.xml

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ PACKAGES = [
     'payments.dotpay',
     'payments.paypal',
     'payments.sagepay',
+    'payments.sofort',
     'payments.stripe',
     'payments.wallet']
 


### PR DESCRIPTION
I added the `*.xml` to the manifest.in. Otherwise it ignores the templates in `/templates/sofort/*.xml`
I also added 'payments.sofort' to setup.py