### PR TITLE
replace IPAddressField with GenericIPAddressField

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -84,7 +84,7 @@ class BasePayment(models.Model):
     billing_country_code = models.CharField(max_length=2, blank=True)
     billing_country_area = models.CharField(max_length=256, blank=True)
     billing_email = models.EmailField(blank=True)
-    customer_ip_address = models.IPAddressField(blank=True)
+    customer_ip_address = models.GenericIPAddressField(blank=True)
     extra_data = models.TextField(blank=True, default='')
     message = models.TextField(blank=True, default='')
     token = models.CharField(max_length=36, blank=True, default='')


### PR DESCRIPTION
Setting up a fresh Saleor instance gives the following warning during the system check.

> System check identified some issues:

> WARNINGS:
> order.Payment.customer_ip_address: (fields.W900) IPAddressField has been deprecated. Support for it (except in historical migrations) will be removed in Django 1.9.
>	HINT: Use GenericIPAddressField instead.

This pull request aims to fix that warning.