### PR TITLE
Making django-payments usable without django.contrib.sites dependency…

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -6,7 +6,6 @@ except ImportError:
     from urllib import urlencode
     from urlparse import urljoin
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 
 PAYMENT_VARIANTS = {
@@ -15,15 +14,14 @@ PAYMENT_VARIANTS = {
 PAYMENT_HOST = getattr(settings, 'PAYMENT_HOST', None)
 PAYMENT_USES_SSL = getattr(settings, 'PAYMENT_USES_SSL', not settings.DEBUG)
 
-if not PAYMENT_HOST:
-    if 'django.contrib.sites' not in settings.INSTALLED_APPS:
-        raise ImproperlyConfigured('The PAYMENT_HOST setting without '
-                                   'the sites app must not be empty.')
-
 
 def get_base_url():
     protocol = 'https' if PAYMENT_USES_SSL else 'http'
-    if not PAYMENT_HOST:
+    if PAYMENT_HOST is not None:
+        if 'django.contrib.sites' not in settings.INSTALLED_APPS:
+            raise ImproperlyConfigured('The PAYMENT_HOST setting without '
+                                       'the sites app must not be empty.')
+        from django.contrib.sites.models import Site
         current_site = Site.objects.get_current()
         domain = current_site.domain
         return '%s://%s' % (protocol, domain)


### PR DESCRIPTION
Making django-payments usable without django.contrib.sites dependency For usage without PAYMENT_HOST setting.

I had a use case were Site is not and shall not be used; this patch helped me to get django-payments working.

I basically moved:
- a test not to raise the exception unnecessarily
- the import of Site down the header, closer to where it's used


edit: I though I saw a closed issue a while ago suggesting to remove the Site dependency, I could not find it so I created this patch.