### PR TITLE
Alternate provider factory

### DIFF
--- a/doc/alternate_provider_factory.rst
+++ b/doc/alternate_provider_factory.rst
@@ -1,0 +1,32 @@
+Alternate provider_factory
+==========================
+
+You might want to be able to provide the ``PAYMENT_VARIANTS`` on a different fashion, such as per entity in your DB. 
+Here's a quick exemple scenario, involving two DB entities for which provider settings has to be different:
+
+Entity1 would have it's own PAYMENT_VARIANTS::
+
+        PAYMENT_VARIANTS = {
+            'stripe': ('payments.stripe.StripeProvider', {
+                'secret_key': 'entity1secretkey',
+                'public_key': 'entity1publickey'}),}
+
+Entity2 also it's own, conflicting with Entity1::
+
+        PAYMENT_VARIANTS = {
+            'stripe': ('payments.stripe.StripeProvider', {
+                'secret_key': 'entity2secretkey',
+                'public_key': 'entity2publickey'}),}
+
+How to solve this problem? We would be able to configure those values, per entity, through Django backend for exemple.
+
+
+#. First define the alternate provider_factory method in the settings::
+
+        PAYMENTS_ALTERNATE_PROVIDER_FACTORY = 'mypaymentapp.utils.alternate_payments_provider_factory'
+
+#. Then define and code your alternate method logic::
+        #mypaymentapp/utils.py
+        def alternate_payments_provider_factory(variant):
+            ...
+

--- a/payments/core.py
+++ b/payments/core.py
@@ -98,7 +98,17 @@ def provider_factory(variant):
     '''
     Return the provider instance based on variant
     '''
-    variants = getattr(settings, 'PAYMENT_VARIANTS', PAYMENT_VARIANTS)
+    PROVIDER_FACTORY = getattr(
+        settings, 'PAYMENTS_ALTERNATE_PROVIDER_FACTORY', None)
+    if PROVIDER_FACTORY is None:
+        variants = getattr(settings, 'PAYMENT_VARIANTS', PAYMENT_VARIANTS)
+    else:
+        module_path, class_name = PROVIDER_FACTORY.rsplit('.', 1)
+        module = __import__(
+            str(module_path), globals(), locals(), [str(class_name)])
+        class_ = getattr(module, class_name)
+        return class_(variant)
+
     handler, config = variants.get(variant, (None, None))
     if not handler:
         raise ValueError('Payment variant does not exist: %s' %


### PR DESCRIPTION
This patch provide an optional alternative to the current core.py/provider_factory method by setting an extra variable in the settings.

You could customize where the PAYMENTS_VARIANTS settings should be (DB instead of settings for exemple); have as many "stripe settings", isolated from one another.

I tried to provide as well a doc with this patch "doc/alternate_provider_factory.rst", it's a draft and unlinked from the other, as-is.


I needed to be able to configure a 'per entity in the DB' PAYMENT_VARIANTS list through the backend of my Django project. This patch helped me resolve this problem.
