### PR TITLE
The Cybersource card-types were inaccurate

### DIFF
--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -350,8 +350,12 @@ class CyberSourceProvider(BasicProvider):
             return '002'
         elif card_type == 'amex':
             return '003'
-        elif card_type == 'jcb':
+        elif card_type == 'discover':
             return '004'
+        elif card_type =='diners':
+            return'005'
+        elif card_type == 'jcb':
+            return '007'
         elif card_type == 'maestro':
             return '042'
 


### PR DESCRIPTION
The cybersource card-types were missing card-types and one was incorrect.

- Added diners club and discover card
- fixed JCB's card-type, it was using the code for the discover card

Here is the documentation to verify the change (page 400)
[Cybersource credit-card documentation](http://apps.cybersource.com/library/documentation/dev_guides/CC_Svcs_SO_API/Credit_Cards_SO_API.pdf)