### PR TITLE
non final capture + return amount + more documentation

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -26,8 +26,8 @@ def get_base_url():
     """
     Returns host url according to project settings. Protocol is chosen by
     checking PAYMENT_USES_SSL variable.
-    If PAYMENT_HOST is not specified, gets domain from Sites. 
-    Otherwise checks if it's callable and returns it's result. If it's not a 
+    If PAYMENT_HOST is not specified, gets domain from Sites.
+    Otherwise checks if it's callable and returns it's result. If it's not a
     callable treats it as domain.
     """
     protocol = 'https' if PAYMENT_USES_SSL else 'http'
@@ -92,7 +92,7 @@ class BasicProvider(object):
             return url + '?' + qs
         return url
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         raise NotImplementedError()
 
     def release(self, payment):

--- a/payments/core.py
+++ b/payments/core.py
@@ -93,12 +93,15 @@ class BasicProvider(object):
         return url
 
     def capture(self, payment, amount=None, final=True):
+        ''' Capture a fraction of the total amount of a payment. Return amount captured or None '''
         raise NotImplementedError()
 
     def release(self, payment):
+        ''' Annilates captured payment '''
         raise NotImplementedError()
 
     def refund(self, payment, amount=None):
+        ''' Refund payment, return amount which was refunded '''
         raise NotImplementedError()
 
 

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -161,7 +161,7 @@ class CyberSourceProvider(BasicProvider):
             self._set_proper_payment_status_from_reason_code(
                 payment, response.reasonCode)
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         if amount is None:
             amount = payment.total
         params = self._prepare_capture(payment, amount=amount)

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -63,7 +63,7 @@ class DummyProvider(BasicProvider):
             return HttpResponseRedirect(payment.get_success_url())
         return HttpResponseRedirect(payment.get_failure_url())
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         payment.change_status(PaymentStatus.CONFIRMED)
         return amount
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -133,12 +133,12 @@ class BasePayment(models.Model):
     def get_process_url(self):
         return reverse('process_payment', kwargs={'token': self.token})
 
-    def capture(self, amount=None):
+    def capture(self, amount=None, final=True):
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be captured.')
         provider = provider_factory(self.variant)
-        amount = provider.capture(self, amount)
+        amount = provider.capture(self, amount, final)
         if amount:
             self.captured_amount = amount
             self.change_status(PaymentStatus.CONFIRMED)

--- a/payments/models.py
+++ b/payments/models.py
@@ -134,16 +134,20 @@ class BasePayment(models.Model):
         return reverse('process_payment', kwargs={'token': self.token})
 
     def capture(self, amount=None, final=True):
+        ''' Capture a fraction of the total amount of a payment. Return amount captured or None '''
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be captured.')
         provider = provider_factory(self.variant)
         amount = provider.capture(self, amount, final)
         if amount:
-            self.captured_amount = amount
-            self.change_status(PaymentStatus.CONFIRMED)
+            self.captured_amount -= amount
+            if final:
+                self.change_status(PaymentStatus.CONFIRMED)
+        return amount
 
     def release(self):
+        ''' Annilates captured payment '''
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be released.')
@@ -152,6 +156,7 @@ class BasePayment(models.Model):
         self.change_status(PaymentStatus.REFUNDED)
 
     def refund(self, amount=None):
+        ''' Refund payment, return amount which was refunded '''
         if self.status != PaymentStatus.CONFIRMED:
             raise ValueError(
                 'Only charged payments can be refunded.')
@@ -159,12 +164,14 @@ class BasePayment(models.Model):
             if amount > self.captured_amount:
                 raise ValueError(
                     'Refund amount can not be greater then captured amount')
-            provider = provider_factory(self.variant)
-            amount = provider.refund(self, amount)
+        provider = provider_factory(self.variant)
+        amount = provider.refund(self, amount)
+        if amount:
             self.captured_amount -= amount
-        if self.captured_amount == 0 and self.status != PaymentStatus.REFUNDED:
-            self.change_status(PaymentStatus.REFUNDED)
-        self.save()
+            if self.captured_amount == 0 and self.status != PaymentStatus.REFUNDED:
+                self.change_status(PaymentStatus.REFUNDED)
+            self.save()
+        return amount
 
     @property
     def attrs(self):

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -252,13 +252,13 @@ class PaypalProvider(BasicProvider):
             'total': str(amount.quantize(
                 CENTS, rounding=ROUND_HALF_UP))}
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         if amount is None:
             amount = payment.total
         amount_data = self.get_amount_data(payment, amount)
         capture_data = {
             'amount': amount_data,
-            'is_final_capture': True
+            'is_final_capture': final
         }
         links = self._get_links(payment)
         url = links['capture']['href']

--- a/payments/stripe/__init__.py
+++ b/payments/stripe/__init__.py
@@ -31,7 +31,7 @@ class StripeProvider(BasicProvider):
             raise RedirectNeeded(payment.get_success_url())
         return form
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         amount = int((amount or payment.total) * 100)
         charge = stripe.Charge.retrieve(payment.transaction_id)
         try:

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -35,7 +35,7 @@ class Payment(Mock):
         self.fraud_status = status
         self.fraud_message = message
 
-    def capture(self, amount=None):
+    def capture(self, amount=None, final=True):
         amount = amount or self.total
         self.captured_amount = amount
         self.change_status(PaymentStatus.CONFIRMED)

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -49,7 +49,9 @@ class TestBasePayment(TestCase):
             mocked_save_method.return_value = None
             mocked_capture_method.return_value = amount
 
-            payment = BasePayment(variant='default', status=PaymentStatus.PREAUTH)
+            captured_amount = Decimal('100')
+            payment = BasePayment(variant='default', captured_amount=captured_amount,
+                                  status=PaymentStatus.PREAUTH)
             payment.capture(amount)
 
             self.assertEqual(payment.status, PaymentStatus.CONFIRMED)
@@ -110,7 +112,7 @@ class TestBasePayment(TestCase):
             payment.refund(refund_amount)
             self.assertEqual(payment.status, status)
             self.assertEqual(payment.captured_amount, captured_amount)
-        self.assertEqual(mocked_refund_method.call_count, 0)
+        self.assertEqual(mocked_refund_method.call_count, 1)
 
     @patch('payments.dummy.DummyProvider.refund')
     def test_refund_partial_success(self, mocked_refund_method):


### PR DESCRIPTION
Add final parameter for final captures. Defaults to true for old logic.
Changing it allows multiple captures.
First only paypal is supported but I have some providers in pipeline which use it too.
There is no check if captured_amount is bigger than total because some providers allow overcapture.

Secondly the amount or None is returned in refund and capture (model). This streamlines the return behaviour of Providers.

At last I add some documentation for the methods. 
