### PR TITLE
make status_changed signal more robust

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import json
 from uuid import uuid4
+import logging
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -10,6 +11,8 @@ from django.utils.translation import ugettext_lazy as _
 from .core import provider_factory
 from . import FraudStatus, PaymentStatus
 
+# Get an instance of a logger
+logger = logging.getLogger(__name__)
 
 class PaymentAttributeProxy(object):
 
@@ -86,7 +89,9 @@ class BasePayment(models.Model):
         self.status = status
         self.message = message
         self.save()
-        status_changed.send(sender=type(self), instance=self)
+        for receiver, result in status_changed.send_robust(sender=type(self), instance=self):
+            if isinstance(result, Exception):
+                logger.critical(result)
 
     def change_fraud_status(self, status, message='', commit=True):
         available_statuses = [choice[0] for choice in FraudStatus.CHOICES]

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -64,9 +64,6 @@ class TestBasePayment(TestCase):
                 payment.change_status(PaymentStatus.WAITING, "fooo")
             self.assertEqual(logs.output, ['CRITICAL:payments.models:Here be dragons'])
 
-
-
-
     @patch('payments.dummy.DummyProvider.capture')
     def test_capture_preauth_successfully(self, mocked_capture_method):
         amount = Decimal('20')

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from unittest import TestCase
 from mock import patch, NonCallableMock
 
+from django.dispatch import Signal
+
 from payments import core
 from .forms import CreditCardPaymentFormWithName, PaymentForm
 from .models import BasePayment
@@ -41,6 +43,29 @@ class TestBasePayment(TestCase):
     def test_capture_with_wrong_status(self):
         payment = BasePayment(variant='default', status=PaymentStatus.WAITING)
         self.assertRaises(ValueError, payment.capture)
+
+    @patch('payments.signals.status_changed', new_callable=Signal)
+    def test_robust_signals(self, mocked_signal):
+        with patch.object(BasePayment, 'save') as mocked_save_method:
+            mocked_save_method.return_value = None
+            def rogue_handler(sender, instance, **kwargs):
+                raise Exception("Here be dragons")
+            def benign_handler(sender, instance, **kwargs):
+                pass
+            class UnrelatedClass(object):
+                pass
+            def unrelated_handler(sender, instance, **kwargs):
+                raise Exception("Should not be called")
+            mocked_signal.connect(rogue_handler, sender=BasePayment)
+            mocked_signal.connect(benign_handler, sender=BasePayment)
+            mocked_signal.connect(unrelated_handler, sender=UnrelatedClass)
+            payment = BasePayment(variant='default', status=PaymentStatus.PREAUTH)
+            with self.assertLogs("payments.models", "CRITICAL") as logs:
+                payment.change_status(PaymentStatus.WAITING, "fooo")
+            self.assertEqual(logs.output, ['CRITICAL:payments.models:Here be dragons'])
+
+
+
 
     @patch('payments.dummy.DummyProvider.capture')
     def test_capture_preauth_successfully(self, mocked_capture_method):

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -60,9 +60,11 @@ class TestBasePayment(TestCase):
             mocked_signal.connect(benign_handler, sender=BasePayment)
             mocked_signal.connect(unrelated_handler, sender=UnrelatedClass)
             payment = BasePayment(variant='default', status=PaymentStatus.PREAUTH)
-            with self.assertLogs("payments.models", "CRITICAL") as logs:
-                payment.change_status(PaymentStatus.WAITING, "fooo")
-            self.assertEqual(logs.output, ['CRITICAL:payments.models:Here be dragons'])
+            # python < 3.4 has no asserLogs
+            if hasattr(self, "assertLogs"):
+                with self.assertLogs("payments.models", "CRITICAL") as logs:
+                    payment.change_status(PaymentStatus.WAITING, "fooo")
+                self.assertEqual(logs.output, ['CRITICAL:payments.models:Here be dragons'])
 
     @patch('payments.dummy.DummyProvider.capture')
     def test_capture_preauth_successfully(self, mocked_capture_method):


### PR DESCRIPTION
Instead of using send, use send_robust and check for errors in the return values. These are logged with logging level critical so they are clearly visible.

If you have a bank facing api it can be really annoying if a signal handler crashes because you don't see the error (in debug mode) and a small unimportant handler can corrupt a transaction. This fixes the issue.
