### PR TITLE
Add external Payments (BankTransfer, DirectPayment)

### DIFF
--- a/payments/authorizenet/__init__.py
+++ b/payments/authorizenet/__init__.py
@@ -23,19 +23,19 @@ class AuthorizeNetProvider(BasicProvider):
                 'Authorize.Net does not support pre-authorization.')
 
     def get_transactions_data(self, payment):
-        data = {
+        billing = payment.get_billing_address()
+        return {
             'x_amount': payment.total,
             'x_currency_code': payment.currency,
             'x_description': payment.description,
-            'x_first_name': payment.billing_first_name,
-            'x_last_name': payment.billing_last_name,
-            'x_address': "%s, %s" % (payment.billing_address_1,
-                                     payment.billing_address_2),
-            'x_city': payment.billing_city,
-            'x_zip': payment.billing_postcode,
-            'x_country': payment.billing_country_area
+            'x_first_name': billing["first_name"],
+            'x_last_name': billing["last_name"],
+            'x_address': "%s, %s" % (billing["address_1"],
+                                     billing["address_2"]),
+            'x_city': billing["city"],
+            'x_zip': billing["postcode"],
+            'x_country': billing["country_area"]
         }
-        return data
 
     def get_product_data(self, payment, extra_data=None):
         data = self.get_transactions_data(payment)

--- a/payments/authorizenet/test_authorizenet.py
+++ b/payments/authorizenet/test_authorizenet.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from . import AuthorizeNetProvider
 from .. import PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
 
 
 LOGIN_ID = 'abcd1234'
@@ -18,26 +22,7 @@ PROCESS_DATA = {
 STATUS_CONFIRMED = '1'
 
 
-class Payment(Mock):
-    id = 1
-    variant = 'authorizenet'
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    transaction_id = None
-    captured_amount = 0
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status):
-        self.status = status
+Payment = create_test_payment()
 
 
 

--- a/payments/braintree/forms.py
+++ b/payments/braintree/forms.py
@@ -41,20 +41,22 @@ class BraintreePaymentForm(CreditCardPaymentFormWithName):
                 'expiration_year': self.cleaned_data.get('expiration').year}
 
     def get_billing_data(self):
+        billing = self.payment.get_billing_address()
         return {
-            'first_name': self.payment.billing_first_name,
-            'last_name': self.payment.billing_last_name,
-            'street_address': self.payment.billing_address_1,
-            'extended_address': self.payment.billing_address_2,
-            'locality': self.payment.billing_city,
-            'region': self.payment.billing_country_area,
-            'postal_code': self.payment.billing_postcode,
-            'country_code_alpha2': self.payment.billing_country_code}
+            'first_name': billing["first_name"],
+            'last_name': billing["last_name"],
+            'street_address': billing["address_1"],
+            'extended_address': billing["address_2"],
+            'locality': billing["city"],
+            'region': billing["country_area"],
+            'postal_code': billing["postcode"],
+            'country_code_alpha2': billing["country_code"]}
 
     def get_customer_data(self):
+        billing = self.payment.get_billing_address()
         return {
-            'first_name': self.payment.billing_first_name,
-            'last_name': self.payment.billing_last_name}
+            'first_name': billing["first_name"],
+            'last_name': billing["last_name"]}
 
     def save(self):
         braintree.Transaction.submit_for_settlement(self.transaction_id)

--- a/payments/braintree/test_braintree.py
+++ b/payments/braintree/test_braintree.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from . import BraintreeProvider
 from .. import PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
 
 
 MERCHANT_ID = 'test11'
@@ -18,26 +22,7 @@ PROCESS_DATA = {
     'cvv2': '1234'}
 
 
-class Payment(Mock):
-    id = 1
-    variant = 'braintree'
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    transaction_id = None
-    captured_amount = 0
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status):
-        self.status = status
+Payment = create_test_payment()
 
 
 class TestBraintreeProvider(TestCase):

--- a/payments/coinbase/test_coinbase.py
+++ b/payments/coinbase/test_coinbase.py
@@ -4,12 +4,16 @@ import hashlib
 import json
 from decimal import Decimal
 from unittest import TestCase
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from django.http import HttpResponse, HttpResponseForbidden
-from mock import MagicMock, patch
 
 from .. import PaymentStatus
 from . import CoinbaseProvider
+from ..testcommon import create_test_payment
 
 PAYMENT_TOKEN = '5a4dae68-2715-4b1e-8bb2-2c2dbe9255f6'
 KEY = 'abc123'
@@ -23,34 +27,7 @@ COINBASE_REQUEST = {
             PAYMENT_TOKEN, KEY)).encode('utf-8')).hexdigest()}}
 
 
-class Payment(object):
-
-    id = 1
-    description = 'payment'
-    currency = 'BTC'
-    total = Decimal(100)
-    status = PaymentStatus.WAITING
-    token = PAYMENT_TOKEN
-    variant = VARIANT
-
-    def change_status(self, status):
-        self.status = status
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_purchased_items(self):
-        return []
-
-    def save(self):
-        return self
-
-    def get_success_url(self):
-        return 'http://success.com'
-
+Payment = create_test_payment(variant=VARIANT, token=PAYMENT_TOKEN, description='payment', currency='BTC', total=Decimal(100))
 
 class TestCoinbaseProvider(TestCase):
 

--- a/payments/core.py
+++ b/payments/core.py
@@ -26,8 +26,8 @@ def get_base_url():
     """
     Returns host url according to project settings. Protocol is chosen by
     checking PAYMENT_USES_SSL variable.
-    If PAYMENT_HOST is not specified, gets domain from Sites. 
-    Otherwise checks if it's callable and returns it's result. If it's not a 
+    If PAYMENT_HOST is not specified, gets domain from Sites.
+    Otherwise checks if it's callable and returns it's result. If it's not a
     callable treats it as domain.
     """
     protocol = 'https' if PAYMENT_USES_SSL else 'http'
@@ -92,7 +92,7 @@ class BasicProvider(object):
             return url + '?' + qs
         return url
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         raise NotImplementedError()
 
     def release(self, payment):

--- a/payments/core.py
+++ b/payments/core.py
@@ -93,12 +93,15 @@ class BasicProvider(object):
         return url
 
     def capture(self, payment, amount=None, final=True):
+        ''' Capture a fraction of the total amount of a payment. Return amount captured or None '''
         raise NotImplementedError()
 
     def release(self, payment):
+        ''' Annilates captured payment '''
         raise NotImplementedError()
 
     def refund(self, payment, amount=None):
+        ''' Refund payment, return amount which was refunded '''
         raise NotImplementedError()
 
 

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -366,15 +366,16 @@ class CyberSourceProvider(BasicProvider):
         return card
 
     def _prepare_billing_data(self, payment):
+        _billing_address = payment.get_billing_address()
         billing = self.client.factory.create('data:BillTo')
-        billing.firstName = payment.billing_first_name
-        billing.lastName = payment.billing_last_name
-        billing.street1 = payment.billing_address_1
-        billing.street2 = payment.billing_address_2
-        billing.city = payment.billing_city
-        billing.postalCode = payment.billing_postcode
-        billing.country = payment.billing_country_code
-        billing.state = payment.billing_country_area
+        billing.firstName = _billing_address["first_name"]
+        billing.lastName = _billing_address["last_name"]
+        billing.street1 = _billing_address["address_1"]
+        billing.street2 = _billing_address["address_2"]
+        billing.city = _billing_address["city"]
+        billing.postalCode = _billing_address["postcode"]
+        billing.country = _billing_address["country_code"]
+        billing.state = _billing_address["country_area"]
         billing.email = payment.billing_email
         billing.ipAddress = payment.customer_ip_address
         return billing

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -161,7 +161,7 @@ class CyberSourceProvider(BasicProvider):
             self._set_proper_payment_status_from_reason_code(
                 payment, response.reasonCode)
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         if amount is None:
             amount = payment.total
         params = self._prepare_capture(payment, amount=amount)

--- a/payments/cybersource/test_cybersource.py
+++ b/payments/cybersource/test_cybersource.py
@@ -2,11 +2,16 @@ from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
 from django.core import signing
-from mock import patch, MagicMock, Mock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from . import CyberSourceProvider, AUTHENTICATE_REQUIRED, ACCEPTED, \
     TRANSACTION_SETTLED
 from .. import PaymentStatus, PurchasedItem, RedirectNeeded
+
+from ..testcommon import create_test_payment
 
 MERCHANT_ID = 'abcd1234'
 PASSWORD = '1234abdd1234abcd'
@@ -20,40 +25,13 @@ PROCESS_DATA = {
     'cvv2': '1234',
     'fingerprint': 'abcd1234'}
 
-
-class Payment(Mock):
-    id = 1
-    variant = 'cybersource'
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    transaction_id = None
-    captured_amount = 0
-    message = ''
-
+_Payment = create_test_payment()
+class Payment(_Payment):
+    # MagicMock is not serializable so overwrite attrs Proxy
     class attrs(object):
         fingerprint_session_id = 'fake'
         merchant_defined_data = {}
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status, message=''):
-        self.status = status
-        self.message = message
-
-    def get_purchased_items(self):
-        return [
-            PurchasedItem(
-                name='foo', quantity=Decimal('10'), price=Decimal('20'),
-                currency='USD', sku='bar')]
-
+        capture = {}
 
 class TestCybersourceProvider(TestCase):
 

--- a/payments/dotpay/test_dotpay.py
+++ b/payments/dotpay/test_dotpay.py
@@ -3,11 +3,15 @@ import hashlib
 from unittest import TestCase
 
 from django.http import HttpResponse, HttpResponseForbidden
-from mock import MagicMock, Mock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from .. import PaymentStatus
 from .forms import ACCEPTED, REJECTED
 from . import DotpayProvider
+from ..testcommon import create_test_payment
 
 VARIANT = 'dotpay'
 PIN = '123'
@@ -45,24 +49,7 @@ def get_post_with_md5(post):
     return post
 
 
-class Payment(Mock):
-    id = 1
-    variant = VARIANT
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status):
-        self.status = status
+Payment = create_test_payment(variant=VARIANT, id=1, currency='USD')
 
 
 class TestDotpayProvider(TestCase):

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -63,7 +63,7 @@ class DummyProvider(BasicProvider):
             return HttpResponseRedirect(payment.get_success_url())
         return HttpResponseRedirect(payment.get_failure_url())
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         payment.change_status(PaymentStatus.CONFIRMED)
         return amount
 

--- a/payments/dummy/test_dummy.py
+++ b/payments/dummy/test_dummy.py
@@ -12,32 +12,12 @@ except ImportError:
 
 from . import DummyProvider
 from .. import FraudStatus, PaymentError, PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
 
 VARIANT = 'dummy-3ds'
 
 
-class Payment(object):
-    id = 1
-    variant = VARIANT
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    fraud_status = ''
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, new_status):
-        self.status = new_status
-
-    def change_fraud_status(self, fraud_status):
-        self.fraud_status = fraud_status
+Payment = create_test_payment(variant=VARIANT)
 
 
 class TestDummy3DSProvider(TestCase):

--- a/payments/externalpayments/__init__.py
+++ b/payments/externalpayments/__init__.py
@@ -1,0 +1,114 @@
+from __future__ import unicode_literals
+
+from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .forms import OrderIdForm, IBANBankingForm
+from .. import PaymentError, PaymentStatus, RedirectNeeded
+from ..core import BasicProvider
+
+class DirectPaymentProvider(BasicProvider):
+    '''
+        Payment is done manually e.g. cash on delivery, voucher in restaurant.
+        Payments are just a placeholder; to allow every further operation set to CONFIRMED.
+
+        skipform:
+            doesn't show form with data
+        usetoken:
+            if you don't verify the name; don't allow people
+            supplying others order numbers (use token)
+            because it is much longer it defaults to off
+        prefix:
+            reference: add prefix to payment id
+
+    '''
+
+    def __init__(self, skipform=True,
+                 usetoken=False, prefix="", **kwargs):
+        super(DirectPaymentProvider, self).__init__(**kwargs)
+        self.skipform = skipform
+        self.prefix = prefix
+        self.usetoken = usetoken
+        if not self._capture:
+            raise ImproperlyConfigured(
+                'Direct Payments do not support pre-authorization.')
+
+    def get_form(self, payment, data=None):
+        if not payment.id:
+            payment.save()
+        if not payment.transaction_id:
+            if self.usetoken:
+                payment.transaction_id = "{}{}-{}".format(self.prefix, payment.id, payment.token)
+            else:
+                payment.transaction_id = "{}{}".format(self.prefix, payment.id)
+            payment.save()
+        if not self.skipform:
+            if not data or not data.get("order", None):
+                return OrderIdForm({"order": payment.transaction_id},
+                                   payment=payment,
+                                   provider=self,
+                                   hidden_inputs=False)
+        payment.change_status(PaymentStatus.CONFIRMED)
+        raise RedirectNeeded(payment.get_success_url())
+
+    def refund(self, payment, amount=None):
+        if not amount:
+            amount = payment.total
+        payment.change_status(PaymentStatus.REFUNDED)
+        return amount
+
+class BankTransferProvider(BasicProvider):
+    '''
+        Banking software or human confirms transaction.
+        Because there is no security problems if somebody pays for somebody else and references can not hold many characters, only the id is required.
+        The form is used to show the user the data he has to send.
+        iban:
+            IBAN number
+        bic:
+            BIC number
+        prefix:
+            reference: add prefix to payment id
+        confirm:
+            set PaymentStatus to CONFIRMED after user confirms
+    '''
+
+    def __init__(self, iban, bic, confirm=False
+                 prefix="", **kwargs):
+        if len(iban) <= 10 or len(bic) != 11:
+            raise ImproperlyConfigured("Wrong IBAN or BIC")
+        self.iban = iban.upper()
+        self.bic = bic.upper()
+        self.confirm = confirm
+        self.prefix = prefix
+        super(AdvancePaymentProvider, self).__init__(**kwargs)
+        if not self._capture:
+            raise ImproperlyConfigured(
+                'Advance Payment does not support pre-authorization.')
+
+    def get_hidden_fields(self, payment):
+        return {
+            'iban': self.iban,
+            'bic': self.bic,
+            'order': payment.transaction_id
+        }
+
+    def get_form(self, payment, data=None):
+        if not payment.id:
+            payment.save()
+        if not payment.transaction_id:
+            payment.transaction_id = "{}{}".format(self.prefix, payment.id)
+            payment.save()
+        if not data or not data.get("order", None):
+            return IBANBankingForm(self.get_hidden_fields(payment), payment=payment, provider=self, hidden_inputs=False)
+        if self.confirm:
+            payment.change_status(PaymentStatus.CONFIRMED)
+        else:
+            payment.change_status(PaymentStatus.WAITING)
+        raise RedirectNeeded(payment.get_success_url())
+
+    def refund(self, payment, amount=None):
+        if not amount:
+            amount = payment.total
+        payment.change_status(PaymentStatus.REFUNDED)
+        return amount

--- a/payments/externalpayments/__init__.py
+++ b/payments/externalpayments/__init__.py
@@ -73,7 +73,7 @@ class BankTransferProvider(BasicProvider):
             set PaymentStatus to CONFIRMED after user confirms
     '''
 
-    def __init__(self, iban, bic, confirm=False
+    def __init__(self, iban, bic, confirm=False,
                  prefix="", **kwargs):
         if len(iban) <= 10 or len(bic) != 11:
             raise ImproperlyConfigured("Wrong IBAN or BIC")

--- a/payments/externalpayments/__init__.py
+++ b/payments/externalpayments/__init__.py
@@ -75,13 +75,13 @@ class BankTransferProvider(BasicProvider):
 
     def __init__(self, iban, bic, confirm=False,
                  prefix="", **kwargs):
-        if len(iban) <= 10 or len(bic) != 11:
+        if len(iban) <= 10 or len(bic) <= 4:
             raise ImproperlyConfigured("Wrong IBAN or BIC")
         self.iban = iban.upper()
         self.bic = bic.upper()
         self.confirm = confirm
         self.prefix = prefix
-        super(AdvancePaymentProvider, self).__init__(**kwargs)
+        super(BankTransferProvider, self).__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Advance Payment does not support pre-authorization.')

--- a/payments/externalpayments/forms.py
+++ b/payments/externalpayments/forms.py
@@ -1,4 +1,6 @@
 from django.utils.translation import ugettext_lazy as _
+from django import forms
+
 from ..forms import PaymentForm
 
 class OrderIdForm(PaymentForm):

--- a/payments/externalpayments/forms.py
+++ b/payments/externalpayments/forms.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext_lazy as _
+from ..forms import PaymentForm
+
+class OrderIdForm(PaymentForm):
+    # only shown, return is ignored
+    order = forms.CharField(widget=forms.TextInput(attrs={'readonly':'readonly'}),\
+                            label=_("Please supply as reference"))
+
+
+class IBANBankingForm(PaymentForm):
+    # only shown, return is ignored
+    iban = forms.CharField(widget=forms.TextInput(attrs={'readonly':'readonly'}), label="IBAN")
+    bic = forms.CharField(widget=forms.TextInput(attrs={'readonly':'readonly'}), label="BIC")
+    order = forms.CharField(widget=forms.TextInput(attrs={'readonly':'readonly'}),\
+                                                   label=_("Please supply as reference"))

--- a/payments/externalpayments/test_externalpayments.py
+++ b/payments/externalpayments/test_externalpayments.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+from . import DirectPaymentProvider, BankTransferProvider
+from .. import PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
+
+Payment = create_test_payment()
+
+
+class TestDirectProvider(TestCase):
+    def setUp(self):
+        self.payment = Payment()
+
+    def test_get_form_skip(self):
+        provider = DirectPaymentProvider()
+        with self.assertRaises(RedirectNeeded):
+            provider.get_form(self.payment)
+        self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
+
+    def test_get_form_noskip(self):
+        provider = DirectPaymentProvider(skipform=False)
+        form = provider.get_form(self.payment)
+        form.is_valid()
+        form.clean()
+        self.assertEqual(self.payment.status, PaymentStatus.WAITING)
+        with self.assertRaises(RedirectNeeded):
+            provider.get_form(self.payment, form.cleaned_data)
+        self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
+
+class TestBankTransferProvider(TestCase):
+    def setUp(self):
+        self.payment = Payment()
+
+    def test_bank_transfer_confirms(self):
+        provider = BankTransferProvider(iban="GL5604449876543210", bic="DABAIE2D", confirm=True)
+        form = provider.get_form(self.payment)
+        form.is_valid()
+        form.clean()
+        self.assertEqual(self.payment.status, PaymentStatus.WAITING)
+        with self.assertRaises(RedirectNeeded):
+            provider.get_form(self.payment, form.cleaned_data)
+        self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
+
+    def test_bank_transfer_confirms_not(self):
+        provider = BankTransferProvider("GL5604449876543210", "DABAIE2D", confirm=False)
+        form = provider.get_form(self.payment)
+        form.is_valid()
+        form.clean()
+        self.assertEqual(self.payment.status, PaymentStatus.WAITING)
+        with self.assertRaises(RedirectNeeded):
+            provider.get_form(self.payment, form.cleaned_data)
+        self.assertEqual(self.payment.status, PaymentStatus.WAITING)

--- a/payments/models.py
+++ b/payments/models.py
@@ -133,12 +133,12 @@ class BasePayment(models.Model):
     def get_process_url(self):
         return reverse('process_payment', kwargs={'token': self.token})
 
-    def capture(self, amount=None):
+    def capture(self, amount=None, final=True):
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be captured.')
         provider = provider_factory(self.variant)
-        amount = provider.capture(self, amount)
+        amount = provider.capture(self, amount, final)
         if amount:
             self.captured_amount = amount
             self.change_status(PaymentStatus.CONFIRMED)

--- a/payments/models.py
+++ b/payments/models.py
@@ -134,16 +134,20 @@ class BasePayment(models.Model):
         return reverse('process_payment', kwargs={'token': self.token})
 
     def capture(self, amount=None, final=True):
+        ''' Capture a fraction of the total amount of a payment. Return amount captured or None '''
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be captured.')
         provider = provider_factory(self.variant)
         amount = provider.capture(self, amount, final)
         if amount:
-            self.captured_amount = amount
-            self.change_status(PaymentStatus.CONFIRMED)
+            self.captured_amount -= amount
+            if final:
+                self.change_status(PaymentStatus.CONFIRMED)
+        return amount
 
     def release(self):
+        ''' Annilates captured payment '''
         if self.status != PaymentStatus.PREAUTH:
             raise ValueError(
                 'Only pre-authorized payments can be released.')
@@ -152,6 +156,7 @@ class BasePayment(models.Model):
         self.change_status(PaymentStatus.REFUNDED)
 
     def refund(self, amount=None):
+        ''' Refund payment, return amount which was refunded '''
         if self.status != PaymentStatus.CONFIRMED:
             raise ValueError(
                 'Only charged payments can be refunded.')
@@ -159,12 +164,14 @@ class BasePayment(models.Model):
             if amount > self.captured_amount:
                 raise ValueError(
                     'Refund amount can not be greater then captured amount')
-            provider = provider_factory(self.variant)
-            amount = provider.refund(self, amount)
+        provider = provider_factory(self.variant)
+        amount = provider.refund(self, amount)
+        if amount:
             self.captured_amount -= amount
-        if self.captured_amount == 0 and self.status != PaymentStatus.REFUNDED:
-            self.change_status(PaymentStatus.REFUNDED)
-        self.save()
+            if self.captured_amount == 0 and self.status != PaymentStatus.REFUNDED:
+                self.change_status(PaymentStatus.REFUNDED)
+            self.save()
+        return amount
 
     @property
     def attrs(self):

--- a/payments/models.py
+++ b/payments/models.py
@@ -141,7 +141,7 @@ class BasePayment(models.Model):
         provider = provider_factory(self.variant)
         amount = provider.capture(self, amount, final)
         if amount:
-            self.captured_amount -= amount
+            self.captured_amount += amount
             if final:
                 self.change_status(PaymentStatus.CONFIRMED)
         return amount

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -252,13 +252,13 @@ class PaypalProvider(BasicProvider):
             'total': str(amount.quantize(
                 CENTS, rounding=ROUND_HALF_UP))}
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         if amount is None:
             amount = payment.total
         amount_data = self.get_amount_data(payment, amount)
         capture_data = {
             'amount': amount_data,
-            'is_final_capture': True
+            'is_final_capture': final
         }
         links = self._get_links(payment)
         url = links['capture']['href']

--- a/payments/sagepay/__init__.py
+++ b/payments/sagepay/__init__.py
@@ -60,6 +60,8 @@ class SagepayProvider(BasicProvider):
     def get_hidden_fields(self, payment):
         payment.save()
         return_url = self.get_return_url(payment)
+        _billing_address = payment.get_billing_address()
+        _shipping_address = payment.get_billing_address()
         data = {
             'VendorTxCode': payment.pk,
             'Amount': "%.2f" % (payment.total,),
@@ -67,23 +69,24 @@ class SagepayProvider(BasicProvider):
             'Description': "Payment #%s" % (payment.pk,),
             'SuccessURL': return_url,
             'FailureURL': return_url,
-            'BillingSurname': payment.billing_last_name,
-            'BillingFirstnames': payment.billing_first_name,
-            'BillingAddress1': payment.billing_address_1,
-            'BillingAddress2': payment.billing_address_2,
-            'BillingCity': payment.billing_city,
-            'BillingPostCode': payment.billing_postcode,
-            'BillingCountry': payment.billing_country_code,
-            'DeliverySurname': payment.billing_last_name,
-            'DeliveryFirstnames': payment.billing_first_name,
-            'DeliveryAddress1': payment.billing_address_1,
-            'DeliveryAddress2': payment.billing_address_2,
-            'DeliveryCity': payment.billing_city,
-            'DeliveryPostCode': payment.billing_postcode,
-            'DeliveryCountry': payment.billing_country_code}
-        if payment.billing_country_code == 'US':
-            data['BillingState'] = payment.billing_country_area
-            data['DeliveryState'] = payment.billing_country_area
+            'BillingSurname': _billing_address["last_name"],
+            'BillingFirstnames': _billing_address["first_name"],
+            'BillingAddress1': _billing_address["address_1"],
+            'BillingAddress2': _billing_address["address_2"],
+            'BillingCity': _billing_address["city"],
+            'BillingPostCode': _billing_address["postcode"],
+            'BillingCountry': _billing_address["country_code"],
+            'DeliverySurname': _shipping_address["last_name"],
+            'DeliveryFirstnames': _shipping_address["first_name"],
+            'DeliveryAddress1': _shipping_address["address_1"],
+            'DeliveryAddress2': _shipping_address["address_2"],
+            'DeliveryCity': _shipping_address["city"],
+            'DeliveryPostCode': _shipping_address["postcode"],
+            'DeliveryCountry': _shipping_address["country_code"]}
+        if _billing_address["country_code"] == 'US':
+            data['BillingState'] = _billing_address["country_area"]
+        if _shipping_address["country_code"] == 'US':
+            data['DeliveryState'] = _shipping_address["country_area"]
         udata = "&".join("%s=%s" % kv for kv in data.items())
         crypt = self.aes_enc(udata)
         return {'VPSProtocol': self._version, 'TxType': 'PAYMENT',

--- a/payments/sagepay/test_sagepay.py
+++ b/payments/sagepay/test_sagepay.py
@@ -1,36 +1,20 @@
 from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from . import SagepayProvider
 from .. import PaymentStatus
+from ..testcommon import create_test_payment
 
 
 VENDOR = 'abcd1234'
 ENCRYPTION_KEY = '1234abdd1234abcd'
 
 
-class Payment(Mock):
-    id = 1
-    variant = 'sagepay'
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    transaction_id = None
-    captured_amount = 0
-    billing_first_name = 'John'
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status):
-        self.status = status
+Payment = create_test_payment()
 
 
 class TestSagepayProvider(TestCase):

--- a/payments/sofort/__init__.py
+++ b/payments/sofort/__init__.py
@@ -12,7 +12,7 @@ from ..core import BasicProvider
 
 
 class SofortProvider(BasicProvider):
-    
+
     def __init__(self, *args, **kwargs):
         self.secret = kwargs.pop('key')
         self.client_id = kwargs.pop('id')
@@ -20,7 +20,7 @@ class SofortProvider(BasicProvider):
         self.endpoint = kwargs.pop(
              'endpoint', 'https://api.sofort.com/api/xml')
         super(SofortProvider, self).__init__(*args, **kwargs)
-    
+
     def post_request(self, xml_request):
         response = requests.post(
             self.endpoint,
@@ -29,7 +29,7 @@ class SofortProvider(BasicProvider):
             auth=(self.client_id, self.secret))
         doc = xmltodict.parse(response.content)
         return doc, response
-        
+
     def get_form(self, payment, data=None):
         if not payment.id:
             payment.save()
@@ -75,12 +75,13 @@ class SofortProvider(BasicProvider):
             payment.captured_amount = payment.total
             payment.change_status(PaymentStatus.CONFIRMED)
             payment.extra_data = json.dumps(doc)
-            sender_data = doc['transactions']['transaction_details']['sender']
-            holder_data = sender_data['holder']
-            first_name, last_name = holder_data.rsplit(' ', 1)
-            payment.billing_first_name = first_name
-            payment.billing_last_name = last_name
-            payment.billing_country_code = sender_data['country_code']
+            # overwriting names should not be possible
+            #sender_data = doc['transactions']['transaction_details']['sender']
+            #holder_data = sender_data['holder']
+            #first_name, last_name = holder_data.rsplit(' ', 1)
+            #payment.billing_first_name = first_name
+            #payment.billing_last_name = last_name
+            #payment.billing_country_code = sender_data['country_code']
             payment.save()
             return redirect(payment.get_success_url())
 

--- a/payments/sofort/test_sofort.py
+++ b/payments/sofort/test_sofort.py
@@ -1,37 +1,21 @@
 from __future__ import unicode_literals
-from unittest import TestCase
-from mock import patch, MagicMock, Mock
 import json
+from unittest import TestCase
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from . import SofortProvider
 from .. import PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
 
 SECRET = 'abcd1234'
 CLIENT_ID = '1234'
 PROJECT_ID = 'abcd'
 
 
-class Payment(Mock):
-    id = 1
-    variant = 'sagepay'
-    currency = 'USD'
-    total = 100
-    status = PaymentStatus.WAITING
-    transaction_id = None
-    captured_amount = 0
-    billing_first_name = 'John'
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_success_url(self):
-        return 'http://success.com'
-
-    def change_status(self, status):
-        self.status = status
+Payment = create_test_payment()
 
 
 class TestSofortProvider(TestCase):

--- a/payments/stripe/__init__.py
+++ b/payments/stripe/__init__.py
@@ -31,7 +31,7 @@ class StripeProvider(BasicProvider):
             raise RedirectNeeded(payment.get_success_url())
         return form
 
-    def capture(self, payment, amount=None):
+    def capture(self, payment, amount=None, final=True):
         amount = int((amount or payment.total) * 100)
         charge = stripe.Charge.retrieve(payment.transaction_id)
         try:

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -2,56 +2,23 @@
 from __future__ import unicode_literals
 from contextlib import contextmanager
 
-from mock import patch, Mock
 from unittest import TestCase
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import stripe
 
 from . import StripeProvider, StripeCardProvider
 from .. import FraudStatus, PaymentStatus, RedirectNeeded
+from ..testcommon import create_test_payment
 
 
 SECRET_KEY = '1234abcd'
 PUBLIC_KEY = 'abcd1234'
 
 
-class Payment(Mock):
-
-    id = 1
-    description = 'payment'
-    currency = 'USD'
-    delivery = 10
-    status = PaymentStatus.WAITING
-    message = None
-    tax = 10
-    total = 100
-    captured_amount = 0
-    transaction_id = None
-
-    def change_status(self, status, message=''):
-        self.status = status
-        self.message = message
-
-    def change_fraud_status(self, status, message='', commit=True):
-        self.fraud_status = status
-        self.fraud_message = message
-
-    def capture(self, amount=None, final=True):
-        amount = amount or self.total
-        self.captured_amount = amount
-        self.change_status(PaymentStatus.CONFIRMED)
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_purchased_items(self):
-        return []
-
-    def get_success_url(self):
-        return 'http://success.com'
-
+Payment = create_test_payment()
 
 @contextmanager
 def mock_stripe_Charge_create(error_msg=None):

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -35,7 +35,7 @@ class Payment(Mock):
         self.fraud_status = status
         self.fraud_message = message
 
-    def capture(self, amount=None):
+    def capture(self, amount=None, final=True):
         amount = amount or self.total
         self.captured_amount = amount
         self.change_status(PaymentStatus.CONFIRMED)

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -49,7 +49,9 @@ class TestBasePayment(TestCase):
             mocked_save_method.return_value = None
             mocked_capture_method.return_value = amount
 
-            payment = BasePayment(variant='default', status=PaymentStatus.PREAUTH)
+            captured_amount = Decimal('100')
+            payment = BasePayment(variant='default', captured_amount=captured_amount,
+                                  status=PaymentStatus.PREAUTH)
             payment.capture(amount)
 
             self.assertEqual(payment.status, PaymentStatus.CONFIRMED)
@@ -110,7 +112,7 @@ class TestBasePayment(TestCase):
             payment.refund(refund_amount)
             self.assertEqual(payment.status, status)
             self.assertEqual(payment.captured_amount, captured_amount)
-        self.assertEqual(mocked_refund_method.call_count, 0)
+        self.assertEqual(mocked_refund_method.call_count, 1)
 
     @patch('payments.dummy.DummyProvider.refund')
     def test_refund_partial_success(self, mocked_refund_method):

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
-from mock import patch, NonCallableMock
+try:
+    from unittest.mock import patch, NonCallableMock
+except ImportError:
+    from mock import  patch, NonCallableMock
 
 from payments import core
 from .forms import CreditCardPaymentFormWithName, PaymentForm

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -49,7 +49,7 @@ class TestBasePayment(TestCase):
             mocked_save_method.return_value = None
             mocked_capture_method.return_value = amount
 
-            captured_amount = Decimal('100')
+            captured_amount = Decimal('0')
             payment = BasePayment(variant='default', captured_amount=captured_amount,
                                   status=PaymentStatus.PREAUTH)
             payment.capture(amount)
@@ -65,7 +65,7 @@ class TestBasePayment(TestCase):
             mocked_save_method.return_value = None
             mocked_capture_method.return_value = amount
 
-            captured_amount = Decimal('100')
+            captured_amount = Decimal('0')
             status = PaymentStatus.PREAUTH
             payment = BasePayment(variant='default', status=status,
                                   captured_amount=captured_amount)

--- a/payments/testcommon.py
+++ b/payments/testcommon.py
@@ -1,0 +1,77 @@
+
+from decimal import Decimal
+from .models import BasePaymentLogic
+from . import PaymentStatus, PurchasedItem
+from .utils import getter_prefixed_address
+from datetime import datetime
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+def create_test_payment(**_kwargs):
+    class TestPayment(Mock, BasePaymentLogic):
+        id = 523
+        pk = id
+        description = 'payment'
+        currency = 'USD'
+        delivery = Decimal(10.8)
+        status = PaymentStatus.WAITING
+        message = ""
+        tax = Decimal(10)
+        token = "354338723"
+        total = Decimal(100)
+        captured_amount = Decimal("0.0")
+        extra_data = ""
+        variant = "undefined"
+        transaction_id = None
+        created = datetime.now()
+        modified = datetime.now()
+
+        billing_first_name = 'John'
+        billing_last_name = 'Smith'
+        billing_address_1 = 'JohnStreet 23'
+        billing_address_2 = ''
+        billing_city = 'Neches'
+        billing_postcode = "75779"
+        billing_country_code = "US"
+        billing_country_area = "Tennessee"
+        billing_email = "example@example.com"
+        customer_ip_address = "192.78.6.6"
+
+        get_billing_address = getter_prefixed_address("billing")
+        get_shipping_address = get_billing_address
+
+        def capture(self, amount=None):
+            amount = amount or self.total
+            self.captured_amount = amount
+            self.change_status(PaymentStatus.CONFIRMED)
+
+        def change_status(self, status, message=''):
+            '''
+            Updates the Payment status and sends the status_changed signal.
+            '''
+            self.status = status
+            self.message = message
+
+        def get_purchased_items(self):
+            return [
+                PurchasedItem(
+                    name='foo', quantity=Decimal('10'), price=Decimal('20'),
+                    currency='USD', sku='bar')]
+
+        def get_failure_url(self):
+            return 'http://cancel.com'
+
+        def get_process_url(self):
+            return 'http://example.com'
+
+        def get_success_url(self):
+            return 'http://success.com'
+
+        def save(self):
+            return self
+    # workaround limitation in python
+    for key, val in _kwargs.items():
+        setattr(TestPayment, key, val)
+    return TestPayment

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -1,6 +1,8 @@
 from datetime import date
+import re
 
 from django.utils.translation import ugettext_lazy as _
+from django.db import models
 
 
 def get_month_choices():
@@ -12,3 +14,55 @@ def get_year_choices():
     year_choices = [(str(x), str(x)) for x in range(
         date.today().year, date.today().year + 15)]
     return [('', _('Year'))] + year_choices
+
+_extract_streetnr = re.compile(r"([0-9]+)\s*$")
+def extract_streetnr(address, fallback=None):
+    ret = _extract_streetnr.findall(address)
+    if ret:
+        return ret[0]
+    else:
+        return fallback
+
+def getter_prefixed_address(prefix):
+    """ create getter for prefixed address format """
+    first_name = "{}_first_name".format(prefix)
+    last_name = "{}_last_name".format(prefix)
+    address_1 = "{}_address_1".format(prefix)
+    address_2 = "{}_address_2".format(prefix)
+    city = "{}_city".format(prefix)
+    postcode = "{}_postcode".format(prefix)
+    country_code = "{}_country_code".format(prefix)
+    country_area = "{}_country_area".format(prefix)
+    def _get_address(self):
+        return {
+            "first_name": getattr(self, first_name, None),
+            "last_name": getattr(self, last_name, None),
+            "address_1": getattr(self, address_1, None),
+            "address_2": getattr(self, address_2, None),
+            "city": getattr(self, city, None),
+            "postcode": getattr(self, postcode, None),
+            "country_code": getattr(self, country_code, None),
+            "country_area": getattr(self, country_area, None)}
+    return _get_address
+
+def add_prefixed_address(prefix):
+    """ add address with prefix to class """
+    first_name = "{}_first_name".format(prefix)
+    last_name = "{}_last_name".format(prefix)
+    address_1 = "{}_address_1".format(prefix)
+    address_2 = "{}_address_2".format(prefix)
+    city = "{}_city".format(prefix)
+    postcode = "{}_postcode".format(prefix)
+    country_code = "{}_country_code".format(prefix)
+    country_area = "{}_country_area".format(prefix)
+    def class_to_customize(dclass):
+        setattr(dclass, first_name, models.CharField(max_length=256, blank=True))
+        setattr(dclass, last_name, models.CharField(max_length=256, blank=True))
+        setattr(dclass, address_1, models.CharField(max_length=256, blank=True))
+        setattr(dclass, address_2, models.CharField(max_length=256, blank=True))
+        setattr(dclass, city, models.CharField(max_length=256, blank=True))
+        setattr(dclass, postcode, models.CharField(max_length=256, blank=True))
+        setattr(dclass, country_code, models.CharField(max_length=2, blank=True))
+        setattr(dclass, country_area, models.CharField(max_length=256, blank=True))
+        return dclass
+    return class_to_customize

--- a/payments/wallet/test_wallet.py
+++ b/payments/wallet/test_wallet.py
@@ -1,14 +1,18 @@
 from __future__ import unicode_literals
 import time
 from decimal import Decimal
-from unittest import TestCase
 
 from django.http import HttpResponse, HttpResponseForbidden
 import jwt
-from mock import MagicMock
+from unittest import TestCase
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 from .. import PaymentStatus
 from . import GoogleWalletProvider
+from ..testcommon import create_test_payment
 
 PAYMENT_TOKEN = '5a4dae68-2715-4b1e-8bb2-2c2dbe9255f6'
 SELLER_ID = 'abc123'
@@ -31,35 +35,7 @@ JWT_DATA = {
         'orderId': '1234567890'}}
 
 
-class Payment(object):
-
-    id = 1
-    description = 'payment'
-    currency = 'USD'
-    delivery = Decimal(10)
-    status = PaymentStatus.WAITING
-    tax = Decimal(10)
-    token = PAYMENT_TOKEN
-    total = Decimal(100)
-    variant = VARIANT
-
-    def change_status(self, status):
-        self.status = status
-
-    def get_failure_url(self):
-        return 'http://cancel.com'
-
-    def get_process_url(self):
-        return 'http://example.com'
-
-    def get_purchased_items(self):
-        return []
-
-    def save(self):
-        return self
-
-    def get_success_url(self):
-        return 'http://success.com'
+Payment = create_test_payment(variant=VARIANT, token=PAYMENT_TOKEN)
 
 
 class TestGoogleWalletProvider(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ PACKAGES = [
     'payments.cybersource',
     'payments.dummy',
     'payments.dotpay',
+    'payments.externalpayments',
     'payments.paypal',
     'payments.sagepay',
     'payments.sofort',

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,17 @@ REQUIREMENTS = [
     'suds-jurko>=0.6',
     'xmltodict>=0.9.2']
 
+TEST_REQUIREMENTS = [
+    'pytest',
+    'pytest-django'
+]
+if sys.version_info.major < 3:
+    TEST_REQUIREMENTS.append('mock')
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
     test_args = []
-    
+
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.pytest_args = []
@@ -76,8 +82,5 @@ setup(
     install_requires=REQUIREMENTS,
     cmdclass={
         'test': PyTest},
-    tests_require=[
-        'mock',
-        'pytest',
-        'pytest-django'],
+    tests_require=TEST_REQUIREMENTS,
     zip_safe=False)


### PR DESCRIPTION
Sometimes it is useful to have placeholders for certain payments (BankTransfer and manual cashing process).
I provide here two Providers for this purpose:
DirectPaymentProvider: versatile Provider, for e.g. voucher systems or cash on delivery.
BankTransferProvider: for normal bank transfers. Some other logic has to validate payments