### PR TITLE
Replaced _format_value to format_value in stripe/widgets.py

### DIFF
--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -36,7 +36,7 @@ class StripeCheckoutWidget(Input):
         del final_attrs['id']
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_text(self._format_value(value))
+            final_attrs['value'] = force_text(self.format_value(value))
         return format_html('<script{0}></script>', flatatt(final_attrs))
 
 

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -37,10 +37,7 @@ class StripeCheckoutWidget(Input):
         del final_attrs['id']
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            if django.VERSION[0] >= 2:
-                final_attrs['value'] = force_text(self.format_value(value))
-            else:
-                final_attrs['value'] = force_text(self._format_value(value))
+            final_attrs['value'] = force_text(self.format_value(value))
         return format_html('<script{0}></script>', flatatt(final_attrs))
 
 

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -8,7 +8,6 @@ from django.forms.widgets import Input, HiddenInput
 from django.utils.html import format_html
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
-import django
 
 
 class StripeCheckoutWidget(Input):

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -40,7 +40,7 @@ class StripeCheckoutWidget(Input):
             if django.VERSION[0] >= 2:
                 final_attrs['value'] = force_text(self.format_value(value))
             else:
-                final_attrs['value'] = _force_text(self.format_value(value))
+                final_attrs['value'] = force_text(self._format_value(value))
         return format_html('<script{0}></script>', flatatt(final_attrs))
 
 

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -8,6 +8,7 @@ from django.forms.widgets import Input, HiddenInput
 from django.utils.html import format_html
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+import django
 
 
 class StripeCheckoutWidget(Input):
@@ -36,7 +37,10 @@ class StripeCheckoutWidget(Input):
         del final_attrs['id']
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            final_attrs['value'] = force_text(self.format_value(value))
+            if django.VERSION[0] >= 2:
+                final_attrs['value'] = force_text(self.format_value(value))
+            else:
+                final_attrs['value'] = _force_text(self.format_value(value))
         return format_html('<script{0}></script>', flatatt(final_attrs))
 
 


### PR DESCRIPTION
_format_value was removed in [Django 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/) and was remplaced by format_value.