### PR TITLE
more parameters for dotpay.pl

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -132,10 +132,13 @@ Dotpay
 
    :param seller_id: Seller ID assigned by Dotpay
    :param pin: PIN assigned by Dotpay
-   :param channel: Default payment channel (consult reference guide)
+   :param channel: Default payment channel (consult reference guide). Ignored if channel_groups is set.
+   :param channel_groups: Payment channels to choose from (consult reference guide). Overrides channel.
    :param lang: UI language
    :param lock: Whether to disable channels other than the default selected above
    :param endpoint: The API endpoint to use. For the production environment, use ``'https://ssl.dotpay.pl/'`` instead
+   :param ignore_last_payment_channel: Display default channel or channel groups instead of last used channel.
+   :param type: Determines what should be displayed after payment is completed (consult reference guide).
 
 Example::
 
@@ -264,7 +267,7 @@ Sofort.com
    :param id: Your sofort.com user id
    :param key: Your secret key
    :param project_id: Your sofort.com project id
-   :param endpoint: The API endpoint to use. 
+   :param endpoint: The API endpoint to use.
 
 Example::
 

--- a/payments/dotpay/__init__.py
+++ b/payments/dotpay/__init__.py
@@ -28,13 +28,17 @@ class DotpayProvider(BasicProvider):
 
     def __init__(self, seller_id, pin,
                  endpoint='https://ssl.dotpay.pl/test_payment/',
-                 channel=0, lang='pl', lock=False, **kwargs):
+                 channel=0, channel_groups=None, ignore_last_payment_channel=False,
+                 lang='pl', lock=False, type=2, **kwargs):
         self.seller_id = seller_id
         self.pin = pin
         self.endpoint = endpoint
         self.channel = channel
+        self.channel_groups = channel_groups
+        self.ignore_last_payment_channel = ignore_last_payment_channel
         self.lang = lang
         self.lock = lock
+        self.type = type
         super(DotpayProvider, self).__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
@@ -54,11 +58,16 @@ class DotpayProvider(BasicProvider):
             'currency': payment.currency,
             'description': payment.description,
             'lang': self.lang,
-            'channel': str(self.channel),
+            'ignore_last_payment_channel':
+                '1' if self.ignore_last_payment_channel else '0',
             'ch_lock': '1' if self.lock else '0',
             'URL': payment.get_success_url(),
             'URLC': self.get_return_url(payment),
-            'type': '1'}
+            'type': str(self.type)}
+        if self.channel_groups:
+            data['channel_groups'] = self.channel_groups
+        else:
+            data['channel'] = str(self.channel)
         return data
 
     def process_data(self, payment, request):

--- a/payments/dotpay/test_dotpay.py
+++ b/payments/dotpay/test_dotpay.py
@@ -116,3 +116,18 @@ class TestDotpayProvider(TestCase):
         provider = DotpayProvider(seller_id='123', pin=PIN)
         response = provider.process_data(self.payment, request)
         self.assertEqual(type(response), HttpResponseForbidden)
+
+    def test_uses_channel_groups_when_set(self):
+        channel_groups = 'K,T'
+        params = {
+            'seller_id': 123,
+            'pin': PIN,
+            'endpoint': 'test.endpoint.com',
+            'channel': 1,
+            'channel_groups': channel_groups,
+            'lang': 'en',
+            'lock': True}
+        provider = DotpayProvider(**params)
+        hidden_fields = provider.get_hidden_fields(self.payment)
+        self.assertEqual(hidden_fields['channel_groups'], channel_groups)
+        self.assertIsNone(hidden_fields.get('channel'))


### PR DESCRIPTION
This pull request adds some useful parameters for Dotpay:
 - channel groups - display all available payment options to the user instead of just one preselected with option to change, which is the behaviour users are used to see in most shops
 - type - some options after payment, eg. display a button to return to the shop after payment has completed
 - ignore last payment type - display a selection of payment channels instead of last used channel