### PR TITLE
Fix CI on master: Stripe provider fixes

### DIFF
--- a/payments/stripe/forms.py
+++ b/payments/stripe/forms.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import json
 import stripe
 from django import forms
 from django.utils.translation import ugettext as _
@@ -38,7 +39,7 @@ class StripeFormMixin(object):
                         description='%s %s' % (
                             self.payment.billing_last_name,
                             self.payment.billing_first_name))
-                except stripe.CardError as e:
+                except stripe.error.CardError as e:
                     # Making sure we retrieve the charge
                     charge_id = e.json_body['error']['charge']
                     self.charge = stripe.Charge.retrieve(charge_id)
@@ -56,7 +57,7 @@ class StripeFormMixin(object):
 
     def save(self):
         self.payment.transaction_id = self.charge.id
-        self.payment.attrs.charge = stripe.util.json.dumps(self.charge)
+        self.payment.attrs.charge = json.dumps(self.charge)
         self.payment.change_status(PaymentStatus.PREAUTH)
         if self.provider._capture:
             self.payment.capture()

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -62,7 +62,7 @@ def mock_stripe_Charge_create(error_msg=None):
     }
     with patch('stripe.Charge.create') as mocked_charge_create:
         if error_msg:
-            mocked_charge_create.side_effect = stripe.CardError(
+            mocked_charge_create.side_effect = stripe.error.CardError(
                 error_msg, param=None, code=None, json_body=json_body)
         else:
             mocked_charge_create.side_effect = lambda **kwargs: {}
@@ -118,7 +118,7 @@ class TestStripeProvider(TestCase):
             name='Example.com store',
             secret_key=SECRET_KEY, public_key=PUBLIC_KEY)
         data = {'stripeToken': 'abcd'}
-        with patch('stripe.util.json.dumps'):
+        with patch('json.dumps'):
             with patch('stripe.Charge.create'):
                 with self.assertRaises(RedirectNeeded) as exc:
                     provider.get_form(payment, data)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     'cryptography>=1.1.0',
     'PyJWT>=1.3.0',
     'requests>=1.2.0',
-    'stripe>=1.9.8',
+    'stripe>=2.6.0',
     'suds-jurko>=0.6',
     'xmltodict>=0.9.2']
 


### PR DESCRIPTION
Tests are currently failing on master for `django==1.11`: <https://travis-ci.org/mirumee/django-payments/builds/418132718>

Clone this repo on a fresh, clean python 3.6 environment and running the tests locally fails with 4 errors in the stripe provider backend.

This PR fixes the tests for the current release of the stripe python library.

* `stripe.CardError` doesn't exist in `stripe==2.6.0` (`setup.py` specifies `stripe>=1.9.8` which currently resolves to `2.6.0`.
* `stripe.util` doesn't exist in 2.6.0