### PR TITLE
Add renderer as None in render since django 2.1 doesn't support Widget.render()  without renderer parameter

### DIFF
--- a/payments/cybersource/forms.py
+++ b/payments/cybersource/forms.py
@@ -12,7 +12,7 @@ from ..forms import CreditCardPaymentFormWithName
 
 class FingerprintWidget(forms.HiddenInput):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         final_attrs = dict(attrs or {}, type=self.input_type, name=name)
         final_attrs.update(self.attrs)
         final_attrs['session_id'] = value

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -28,7 +28,7 @@ class StripeCheckoutWidget(Input):
         kwargs['attrs'].update(attrs)
         super(StripeCheckoutWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         final_attrs = dict(attrs or {}, src='https://checkout.stripe.com/checkout.js')

--- a/payments/widgets.py
+++ b/payments/widgets.py
@@ -5,7 +5,7 @@ from django.forms.widgets import TextInput, MultiWidget, Select
 
 class CreditCardNumberWidget(TextInput):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value:
             value = re.sub('[\s-]', '', value)
             if len(value) == 16:


### PR DESCRIPTION
In Django 2.1, support for ```Widget.render``` methods without the renderer argument is removed.

This PR fixed the compatibility with django 2.1