### PR TITLE
Test with Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,32 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 env:
   - DJANGO="1.11"
-  - DJANGO="2.0"
+  - DJANGO="2.1"
   - DJANGO="master"
 matrix:
+  include:
+    - python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="2.1"
+    - python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="master"
   allow_failures:
-    - python: "3.4"
-      env: DJANGO="2.0"
-    - python: "3.4"
-      env: DJANGO="master"
-    - python: "3.5"
-      env: DJANGO="2.0"
     - python: "3.5"
       env: DJANGO="master"
     - python: "3.6"
-      env: DJANGO="2.0"
-    - python: "3.6"
+      env: DJANGO="master"
+    - python: "3.7"
       env: DJANGO="master"
   exclude:
     - python: "2.7"
-      env: DJANGO="2.0"
+      env: DJANGO="2.1"
     - python: "2.7"
       env: DJANGO="master"
 after_success: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27-django111, py{34,35,36}-django{111,20,_master}
+envlist = py27-django111, py{35,36,37}-django{111,21,_master}
 
 [testenv]
 usedevelop=True
 deps=
     coverage
     django111: django>=1.11a1,<1.12
-    django20: Django>=2.0a1,<2.1
+    django21: Django>=2.1a1,<2.2
     django_master: https://github.com/django/django/archive/master.tar.gz
     mock
     pytest
@@ -20,13 +20,13 @@ DJANGO_SETTINGS_MODULE = test_settings
 [travis]
 python =
     2.7: py27
-    3.4: py34
     3.5: py35
     3.6: py36
+    3.7: py37
 unignore_outcomes = True
 
 [travis:env]
 DJANGO =
     1.11: django111
-    2.0: django2.0
+    2.1: django21
     master: django_master


### PR DESCRIPTION
Updating the testing matrix to reflect our support policy: lastest LTS (1.11) and latest stable (2.1).