### PR TITLE
Add a note about INSTALLED_APPS to an installation guide

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,6 +6,8 @@ Installation
    .. code-block:: bash
 
       $ pip install django-payments
+      
+#. Add `payments` to your `INSTALLED_APPS`      
 
 #. Add the callback processor to your URL router::
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ Installation
 
       $ pip install django-payments
       
-#. Add `payments` to your `INSTALLED_APPS`      
+#. Add ``payments`` to your ``INSTALLED_APPS``.
 
 #. Add the callback processor to your URL router::
 


### PR DESCRIPTION
This is pretty obvious, but while following the install guide, I forgot about it and got stuck on Django not finding templates :)