### PR TITLE
Use `Payment.billing_email` as `email` and `receipt_email` for Stripe

### DIFF
--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -26,6 +26,7 @@ class Payment(Mock):
     total = 100
     captured_amount = 0
     transaction_id = None
+    billing_email = "john@doe.com"
 
     def change_status(self, status, message=''):
         self.status = status

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -102,6 +102,28 @@ class TestStripeProvider(TestCase):
                 PUBLIC_KEY, store_name)
             in str(form))
 
+    def test_form_contains_stripe_script_withou_billing_email(self):
+        """
+        If billing email is not set, it should generate the script as expected
+        """
+        payment = Payment()
+        store_name = 'Test store'
+        provider = StripeProvider(
+            name=store_name,
+            secret_key=SECRET_KEY, public_key=PUBLIC_KEY)
+
+        form = provider.get_form(payment)
+
+        payment.billing_email = None
+        form = provider.get_form(payment)
+        self.assertTrue(
+            '<script class="stripe-button" data-amount="10000" '
+            'data-currency="USD" data-description="payment" '
+            'data-image="" data-key="%s" data-name="%s" '
+            'src="https://checkout.stripe.com/checkout.js"></script>' % (
+                PUBLIC_KEY, store_name)
+            in str(form))
+
     def test_provider_raises_redirect_needed_when_token_does_not_exist(self):
         payment = Payment()
         provider = StripeProvider(

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -96,8 +96,8 @@ class TestStripeProvider(TestCase):
         form = provider.get_form(payment)
         self.assertTrue(
             '<script class="stripe-button" data-amount="10000" '
-            'data-currency="USD" data-description="payment" data-image="" '
-            'data-key="%s" data-name="%s" '
+            'data-currency="USD" data-description="payment" data-email="john@doe.com" '
+            'data-image="" data-key="%s" data-name="%s" '
             'src="https://checkout.stripe.com/checkout.js"></script>' % (
                 PUBLIC_KEY, store_name)
             in str(form))

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -20,6 +20,7 @@ class StripeCheckoutWidget(Input):
             'data-key': provider.public_key,
             'data-image': provider.image,
             'data-name': provider.name,
+            'data-email': payment.billing_email,
             'data-description': payment.description or _('Total payment'),
             # Stripe accepts cents
             'data-amount': int(payment.total * 100),


### PR DESCRIPTION
It provides a better UX interacting with the **Stripe's payment form** and improves the **Stripe payment flow** ensuring that an email will be ready to be sended to the payment creator if a receipt is requested (due to the automatic Stripe payment notifications flow, or due to a receipt request using the Dashboard).

Concretely, 
- auto-injects `Payment.billing_email` if exists into the payment form [b8862f8]
- integrates the `receipt_email` property for the `Charge` creation [1dd7fd0]


### Fixed issues
Fix #57
Fix #185

