### PR TITLE
Fix testing with Python 2 and Django>=2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 env:
   - DJANGO="1.11"
   - DJANGO="2.1"
+  - DJANGO="2.2"
+  - DJANGO="3.0"
   - DJANGO="master"
 matrix:
   include:
@@ -14,6 +16,14 @@ matrix:
       sudo: required
       dist: xenial
       env: DJANGO="2.1"
+    - python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="2.2"
+    - python: "3.7"
+      sudo: required
+      dist: xenial
+      env: DJANGO="3.0"
     - python: "3.7"
       sudo: required
       dist: xenial
@@ -30,6 +40,8 @@ matrix:
       env: DJANGO="2.1"
     - python: "2.7"
       env: DJANGO="master"
+    - python: "3.5"
+      env: DJANGO="3.0"
 after_success: codecov
 install: pip install tox-travis codecov
 script: tox

--- a/payments/wallet/widgets.py
+++ b/payments/wallet/widgets.py
@@ -19,5 +19,8 @@ class WalletWidget(HiddenInput):
     @property
     def media(self):
         media = super(WalletWidget, self).media
-        media._js = self.js
+        try:  # Django < 2.2
+            media._js = self.js
+        except AttributeError:
+            media._js_lists = [self.js]
         return media

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,11 @@ REQUIREMENTS = [
     'xmltodict>=0.9.2']
 
 
+# Braintree does not support Python 2 from version 4.0.0
+if sys.version_info[0] <= 2:
+    REQUIREMENTS[0] = 'braintree>=3.14.0,<4.0.0'
+
+
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
     test_args = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django111, py{35,36,37}-django{111,21,_master}
+envlist = py27-django111, py{35,36,37}-django{111,21,22,30,_master}
 
 [testenv]
 usedevelop=True
@@ -7,6 +7,8 @@ deps=
     coverage
     django111: django>=1.11a1,<1.12
     django21: Django>=2.1a1,<2.2
+    django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
     django_master: https://github.com/django/django/archive/master.tar.gz
     mock
     pytest
@@ -29,4 +31,6 @@ unignore_outcomes = True
 DJANGO =
     1.11: django111
     2.1: django21
+    2.2: django22
+    3.0: django30
     master: django_master


### PR DESCRIPTION
This fixes tests and adds newer Django versions to testing matrix.

Braintree stopped working in Python 2 with version `4.0.0`, so I restricted the version in `setup.py`. Alternative would be to drop Python 2 support in `django-payments` accordingly.