### PR TITLE
Drop support for EOL'd Pythons and Djangos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 env:
-  - DJANGO="1.11"
-  - DJANGO="2.1"
   - DJANGO="2.2"
   - DJANGO="3.0"
-  - DJANGO="master"
 matrix:
   include:
-    - python: "3.7"
-      sudo: required
-      dist: xenial
-      env: DJANGO="2.1"
     - python: "3.7"
       sudo: required
       dist: xenial
@@ -40,18 +32,16 @@ matrix:
       sudo: required
       dist: xenial
       env: DJANGO="3.1"
+    - python: "3.8"
+      sudo: required
+      dist: xenial
+      env: DJANGO="master"
   allow_failures:
-    - python: "3.5"
-      env: DJANGO="master"
-    - python: "3.6"
-      env: DJANGO="master"
     - python: "3.7"
       env: DJANGO="master"
-  exclude:
-    - python: "2.7"
-      env: DJANGO="2.1"
-    - python: "2.7"
+    - python: "3.8"
       env: DJANGO="master"
+  exclude:
     - python: "3.5"
       env: DJANGO="3.0"
 after_success: codecov

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-payments'
-copyright = u'2010-2013, Mirumee Software'
+project = 'django-payments'
+copyright = '2010-2013, Mirumee Software'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -168,8 +168,8 @@ htmlhelp_basename = 'django-paymentsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-payments.tex', u'django-payments Documentation',
-   u'Mirumee Software', 'manual'),
+  ('index', 'django-payments.tex', 'django-payments Documentation',
+   'Mirumee Software', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # django-payments documentation build configuration file, created by
 # sphinx-quickstart on Thu Sep 30 16:25:38 2010.
 #

--- a/payments/__init__.py
+++ b/payments/__init__.py
@@ -48,7 +48,7 @@ class RedirectNeeded(Exception):
 class PaymentError(Exception):
 
     def __init__(self, message, code=None, gateway_message=None):
-        super(PaymentError, self).__init__(message)
+        super().__init__(message)
         self.code = code
         self.gateway_message = gateway_message
 

--- a/payments/__init__.py
+++ b/payments/__init__.py
@@ -1,9 +1,6 @@
 from collections import namedtuple
-try:
-    from django.db.models import get_model
-except ImportError:
-    from django.apps import apps
-    get_model = apps.get_model
+
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import pgettext_lazy
@@ -69,7 +66,7 @@ def get_payment_model():
     except (ValueError, AttributeError):
         raise ImproperlyConfigured('PAYMENT_MODEL must be of the form '
                                    '"app_label.model_name"')
-    payment_model = get_model(app_label, model_name)
+    payment_model = apps.get_model(app_label, model_name)
     if payment_model is None:
         msg = (
             'PAYMENT_MODEL refers to model "%s" that has not been installed' %

--- a/payments/authorizenet/__init__.py
+++ b/payments/authorizenet/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseForbidden
 import requests

--- a/payments/authorizenet/__init__.py
+++ b/payments/authorizenet/__init__.py
@@ -15,7 +15,7 @@ class AuthorizeNetProvider(BasicProvider):
         self.login_id = login_id
         self.transaction_key = transaction_key
         self.endpoint = endpoint
-        super(AuthorizeNetProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Authorize.Net does not support pre-authorization.')
@@ -27,7 +27,7 @@ class AuthorizeNetProvider(BasicProvider):
             'x_description': payment.description,
             'x_first_name': payment.billing_first_name,
             'x_last_name': payment.billing_last_name,
-            'x_address': "%s, %s" % (payment.billing_address_1,
+            'x_address': "{}, {}".format(payment.billing_address_1,
                                      payment.billing_address_2),
             'x_city': payment.billing_city,
             'x_zip': payment.billing_postcode,

--- a/payments/authorizenet/forms.py
+++ b/payments/authorizenet/forms.py
@@ -9,7 +9,7 @@ RESPONSE_STATUS = {
 class PaymentForm(CreditCardPaymentForm):
 
     def clean(self):
-        cleaned_data = super(PaymentForm, self).clean()
+        cleaned_data = super().clean()
 
         if not self.errors:
             if not self.payment.transaction_id:

--- a/payments/authorizenet/forms.py
+++ b/payments/authorizenet/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from ..forms import CreditCardPaymentForm
 from .. import PaymentStatus
 

--- a/payments/authorizenet/test_authorizenet.py
+++ b/payments/authorizenet/test_authorizenet.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from . import AuthorizeNetProvider
 from .. import PaymentStatus, RedirectNeeded

--- a/payments/braintree/__init__.py
+++ b/payments/braintree/__init__.py
@@ -21,7 +21,7 @@ class BraintreeProvider(BasicProvider):
         braintree.Configuration.configure(
             environment, merchant_id=self.merchant_id,
             public_key=self.public_key, private_key=self.private_key)
-        super(BraintreeProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Braintree does not support pre-authorization.')

--- a/payments/braintree/__init__.py
+++ b/payments/braintree/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import braintree
 from django.core.exceptions import ImproperlyConfigured
 

--- a/payments/braintree/forms.py
+++ b/payments/braintree/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import braintree
 
 from ..forms import CreditCardPaymentFormWithName

--- a/payments/braintree/test_braintree.py
+++ b/payments/braintree/test_braintree.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from . import BraintreeProvider
 from .. import PaymentStatus, RedirectNeeded

--- a/payments/coinbase/__init__.py
+++ b/payments/coinbase/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from collections import OrderedDict
 
 import hashlib

--- a/payments/coinbase/__init__.py
+++ b/payments/coinbase/__init__.py
@@ -24,13 +24,13 @@ class CoinbaseProvider(BasicProvider):
             'endpoint', 'sandbox.coinbase.com')
         self.key = kwargs.pop('key')
         self.secret = kwargs.pop('secret')
-        super(CoinbaseProvider, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Coinbase does not support pre-authorization.')
 
     def get_custom_token(self, payment):
-        value = 'coinbase-%s-%s' % (payment.token, self.key)
+        value = 'coinbase-{}-{}'.format(payment.token, self.key)
         return hashlib.md5(value.encode('utf-8')).hexdigest()
 
     def get_checkout_code(self, payment):
@@ -63,7 +63,7 @@ class CoinbaseProvider(BasicProvider):
 
     def get_action(self, payment):
         checkout_url = self.checkout_url % {'endpoint': self.endpoint}
-        return '%s/%s' % (checkout_url, self.get_checkout_code(payment))
+        return '{}/{}'.format(checkout_url, self.get_checkout_code(payment))
 
     def get_hidden_fields(self, payment):
         return {}

--- a/payments/coinbase/test_coinbase.py
+++ b/payments/coinbase/test_coinbase.py
@@ -17,11 +17,11 @@ VARIANT = 'coinbase'
 COINBASE_REQUEST = {
     'order': {
         'transaction': {'id': '123456'},
-        'custom': hashlib.md5(('coinbase-%s-%s' % (
+        'custom': hashlib.md5(('coinbase-{}-{}'.format(
             PAYMENT_TOKEN, KEY)).encode('utf-8')).hexdigest()}}
 
 
-class Payment(object):
+class Payment:
 
     id = 1
     description = 'payment'

--- a/payments/coinbase/test_coinbase.py
+++ b/payments/coinbase/test_coinbase.py
@@ -1,12 +1,10 @@
-from __future__ import unicode_literals
-
 import hashlib
 import json
 from decimal import Decimal
 from unittest import TestCase
 
 from django.http import HttpResponse, HttpResponseForbidden
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from .. import PaymentStatus
 from . import CoinbaseProvider

--- a/payments/core.py
+++ b/payments/core.py
@@ -34,10 +34,10 @@ def get_base_url():
         domain = PAYMENT_HOST()
     else:
         domain = PAYMENT_HOST
-    return '%s://%s' % (protocol, domain)
+    return '{}://{}'.format(protocol, domain)
 
 
-class BasicProvider(object):
+class BasicProvider:
     '''
     This class defines the provider API. It should not be instantiated
     directly. Use factory instead.

--- a/payments/core.py
+++ b/payments/core.py
@@ -1,10 +1,6 @@
-from __future__ import unicode_literals
 import re
-try:
-    from urllib.parse import urljoin, urlencode
-except ImportError:
-    from urllib import urlencode
-    from urlparse import urljoin
+from urllib.parse import urljoin, urlencode
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -26,8 +22,8 @@ def get_base_url():
     """
     Returns host url according to project settings. Protocol is chosen by
     checking PAYMENT_USES_SSL variable.
-    If PAYMENT_HOST is not specified, gets domain from Sites. 
-    Otherwise checks if it's callable and returns it's result. If it's not a 
+    If PAYMENT_HOST is not specified, gets domain from Sites.
+    Otherwise checks if it's callable and returns it's result. If it's not a
     callable treats it as domain.
     """
     protocol = 'https' if PAYMENT_USES_SSL else 'http'

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -50,13 +50,13 @@ class CyberSourceProvider(BasicProvider):
             local_path = local_path.replace(os.path.sep, '/')
         if not local_path.startswith('/'):
             # windows paths don't start with '/'
-            local_path = '/%s' % (local_path,)
+            local_path = '/{}'.format(local_path)
         if kwargs.pop('sandbox', True):
-            wsdl_path = 'file://%s/%s' % (local_path, WSDL_PATH_TEST)
+            wsdl_path = 'file://{}/{}'.format(local_path, WSDL_PATH_TEST)
             self.endpoint = (
                 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor')
         else:
-            wsdl_path = 'file://%s/%s' % (local_path, WSDL_PATH)
+            wsdl_path = 'file://{}/{}'.format(local_path, WSDL_PATH)
             self.endpoint = (
                 'https://ics2ws.ic3.com/commerce/1.x/transactionProcessor')
         self.client = suds.client.Client(wsdl_path)
@@ -69,7 +69,7 @@ class CyberSourceProvider(BasicProvider):
             password=self.password)
         security_header.tokens.append(security_token)
         self.client.set_options(soapheaders=[security_header.xml()])
-        super(CyberSourceProvider, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_form(self, payment, data=None):
         if payment.status == PaymentStatus.WAITING:

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import datetime
 import os.path
 

--- a/payments/cybersource/forms.py
+++ b/payments/cybersource/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from uuid import uuid4
 
 from django import forms

--- a/payments/cybersource/forms.py
+++ b/payments/cybersource/forms.py
@@ -27,10 +27,10 @@ class FingerprintInput(forms.CharField):
         self.org_id = org_id
         self.merchant_id = merchant_id
         self.fingerprint_url = fingerprint_url
-        super(FingerprintInput, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def widget_attrs(self, widget):
-        attrs = super(FingerprintInput, self).widget_attrs(widget=widget)
+        attrs = super().widget_attrs(widget=widget)
         attrs['org_id'] = self.org_id
         attrs['merchant_id'] = self.merchant_id
         attrs['fingerprint_url'] = self.fingerprint_url
@@ -40,7 +40,7 @@ class FingerprintInput(forms.CharField):
 class PaymentForm(CreditCardPaymentFormWithName):
 
     def __init__(self, *args, **kwargs):
-        super(PaymentForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if self.provider.org_id:
             try:
                 fingerprint_id = self.payment.attrs.fingerprint_session_id
@@ -53,7 +53,7 @@ class PaymentForm(CreditCardPaymentFormWithName):
                 fingerprint_url=self.provider.fingerprint_url)
 
     def clean(self):
-        cleaned_data = super(PaymentForm, self).clean()
+        cleaned_data = super().clean()
         if not self.errors:
             if self.provider.org_id:
                 fingerprint = cleaned_data['fingerprint']

--- a/payments/cybersource/test_cybersource.py
+++ b/payments/cybersource/test_cybersource.py
@@ -1,8 +1,7 @@
-from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
 from django.core import signing
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from . import CyberSourceProvider, AUTHENTICATE_REQUIRED, ACCEPTED, \
     TRANSACTION_SETTLED

--- a/payments/cybersource/test_cybersource.py
+++ b/payments/cybersource/test_cybersource.py
@@ -30,7 +30,7 @@ class Payment(Mock):
     captured_amount = 0
     message = ''
 
-    class attrs(object):
+    class attrs:
         fingerprint_session_id = 'fake'
         merchant_defined_data = {}
 

--- a/payments/dotpay/__init__.py
+++ b/payments/dotpay/__init__.py
@@ -38,7 +38,7 @@ class DotpayProvider(BasicProvider):
         self.lang = lang
         self.lock = lock
         self.type = type
-        super(DotpayProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Dotpay does not support pre-authorization.')

--- a/payments/dotpay/__init__.py
+++ b/payments/dotpay/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from decimal import Decimal
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, HttpResponseForbidden

--- a/payments/dotpay/forms.py
+++ b/payments/dotpay/forms.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import hashlib
 
 from django import forms

--- a/payments/dotpay/forms.py
+++ b/payments/dotpay/forms.py
@@ -44,12 +44,12 @@ class ProcessPaymentForm(forms.Form):
     signature = forms.CharField(required=True)
 
     def __init__(self, payment, pin, **kwargs):
-        super(ProcessPaymentForm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.pin = pin
         self.payment = payment
 
     def clean(self):
-        cleaned_data = super(ProcessPaymentForm, self).clean()
+        cleaned_data = super().clean()
         if not self.errors:
             key_vars = (
                 self.pin,

--- a/payments/dotpay/test_dotpay.py
+++ b/payments/dotpay/test_dotpay.py
@@ -1,9 +1,8 @@
-from __future__ import unicode_literals
 import hashlib
 from unittest import TestCase
 
 from django.http import HttpResponse, HttpResponseForbidden
-from mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 
 from .. import PaymentStatus
 from .forms import COMPLETED, REJECTED

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -36,7 +36,7 @@ class DummyProvider(BasicProvider):
                     process_url = payment.get_process_url()
                     params = urlencode(
                         {'verification_result': verification_result})
-                    redirect_url = '%s?%s' % (process_url, params)
+                    redirect_url = '{}?{}'.format(process_url, params)
                     raise RedirectNeeded(redirect_url)
                 elif gateway_response == 'failure':
                     # Gateway raises error (HTTP 500 for example)

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -1,12 +1,6 @@
-from __future__ import unicode_literals
-try:
-    # For Python 3.0 and later
-    from urllib.error import URLError
-    from urllib.parse import urlencode
-except ImportError:
-    # Fall back to Python 2's urllib2
-    from urllib2 import URLError
-    from urllib import urlencode
+from urllib.error import URLError
+from urllib.parse import urlencode
+
 from django.http import HttpResponseRedirect
 
 from .forms import DummyForm

--- a/payments/dummy/forms.py
+++ b/payments/dummy/forms.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django import forms
 
 from ..forms import PaymentForm

--- a/payments/dummy/forms.py
+++ b/payments/dummy/forms.py
@@ -18,7 +18,7 @@ class DummyForm(PaymentForm):
                                             required=False)
 
     def clean(self):
-        cleaned_data = super(DummyForm, self).clean()
+        cleaned_data = super().clean()
         gateway_response = cleaned_data.get('gateway_response')
         verification_result = cleaned_data.get('verification_result')
         if gateway_response == '3ds-redirect' and not verification_result:

--- a/payments/dummy/test_dummy.py
+++ b/payments/dummy/test_dummy.py
@@ -9,7 +9,7 @@ from .. import FraudStatus, PaymentError, PaymentStatus, RedirectNeeded
 VARIANT = 'dummy-3ds'
 
 
-class Payment(object):
+class Payment:
     id = 1
     variant = VARIANT
     currency = 'USD'
@@ -96,7 +96,7 @@ class TestDummy3DSProvider(TestCase):
             'verification_result': verification_result
         }
         params = urlencode({'verification_result': verification_result})
-        expected_redirect = '%s?%s' % (self.payment.get_process_url(), params)
+        expected_redirect = '{}?{}'.format(self.payment.get_process_url(), params)
 
         with self.assertRaises(RedirectNeeded) as exc:
             provider.get_form(self.payment, data)

--- a/payments/dummy/test_dummy.py
+++ b/payments/dummy/test_dummy.py
@@ -1,14 +1,7 @@
 from unittest import TestCase
-try:
-    from urllib.error import URLError
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
-    from urllib2 import URLError
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
+from urllib.error import URLError
+from urllib.parse import urlencode
 
 from . import DummyProvider
 from .. import FraudStatus, PaymentError, PaymentStatus, RedirectNeeded

--- a/payments/fields.py
+++ b/payments/fields.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from calendar import monthrange
 from datetime import date
 import re

--- a/payments/fields.py
+++ b/payments/fields.py
@@ -22,12 +22,12 @@ class CreditCardNumberField(forms.CharField):
     def __init__(self, valid_types=None, *args, **kwargs):
         self.valid_types = valid_types
         kwargs['max_length'] = kwargs.pop('max_length', 32)
-        super(CreditCardNumberField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def to_python(self, value):
         if value is not None:
-            value = re.sub('[\s-]+', '', value)
-        return super(CreditCardNumberField, self).to_python(value)
+            value = re.sub(r'[\s-]+', '', value)
+        return super().to_python(value)
 
     def validate(self, value):
         card_type, issuer_name = get_credit_card_issuer(value)
@@ -87,12 +87,12 @@ class CreditCardExpiryField(forms.MultiValueField):
                            'required': 'required'})),
         )
 
-        super(CreditCardExpiryField, self).__init__(fields, *args, **kwargs)
+        super().__init__(fields, *args, **kwargs)
         self.widget = CreditCardExpiryWidget(widgets=[fields[0].widget,
                                                       fields[1].widget])
 
     def clean(self, value):
-        exp = super(CreditCardExpiryField, self).clean(value)
+        exp = super().clean(value)
         if exp and date.today() > exp:
             raise forms.ValidationError(
                 "The expiration date you entered is in the past.")
@@ -123,7 +123,7 @@ class CreditCardVerificationField(forms.CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = kwargs.pop('max_length', 4)
-        super(CreditCardVerificationField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def validate(self, value):
         if value in validators.EMPTY_VALUES and self.required:

--- a/payments/forms.py
+++ b/payments/forms.py
@@ -1,9 +1,5 @@
-from __future__ import unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
+from collections import OrderedDict
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _

--- a/payments/forms.py
+++ b/payments/forms.py
@@ -1,4 +1,3 @@
-
 from collections import OrderedDict
 
 from django import forms
@@ -17,12 +16,12 @@ class PaymentForm(forms.Form):
     def __init__(self, data=None, action='', method='post', provider=None,
                  payment=None, hidden_inputs=True, autosubmit=False):
         if hidden_inputs and data is not None:
-            super(PaymentForm, self).__init__(auto_id=False)
+            super().__init__(auto_id=False)
             for key, val in data.items():
                 widget = forms.widgets.HiddenInput()
                 self.fields[key] = forms.CharField(initial=val, widget=widget)
         else:
-            super(PaymentForm, self).__init__(data=data)
+            super().__init__(data=data)
         self.action = action
         self.autosubmit = autosubmit
         self.method = method
@@ -41,7 +40,7 @@ class CreditCardPaymentForm(PaymentForm):
             ' For American Express the four digits found on the front side.'))
 
     def __init__(self, *args, **kwargs):
-        super(CreditCardPaymentForm, self).__init__(
+        super().__init__(
             hidden_inputs=False, *args,  **kwargs)
         if hasattr(self, 'VALID_TYPES'):
             self.fields['number'].valid_types = self.VALID_TYPES
@@ -52,7 +51,7 @@ class CreditCardPaymentFormWithName(CreditCardPaymentForm):
     name = CreditCardNameField(label=_('Name on Credit Card'), max_length=128)
 
     def __init__(self, *args, **kwargs):
-        super(CreditCardPaymentFormWithName, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         name_field = self.fields.pop('name')
         fields = OrderedDict({'name': name_field})
         fields.update(self.fields)

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 from uuid import uuid4
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -9,11 +9,11 @@ from . import FraudStatus, PaymentStatus
 from .core import provider_factory
 
 
-class PaymentAttributeProxy(object):
+class PaymentAttributeProxy:
 
     def __init__(self, payment):
         self._payment = payment
-        super(PaymentAttributeProxy, self).__init__()
+        super().__init__()
 
     def __getattr__(self, item):
         data = json.loads(self._payment.extra_data or '{}')
@@ -21,7 +21,7 @@ class PaymentAttributeProxy(object):
 
     def __setattr__(self, key, value):
         if key == '_payment':
-            return super(PaymentAttributeProxy, self).__setattr__(key, value)
+            return super().__setattr__(key, value)
         try:
             data = json.loads(self._payment.extra_data)
         except ValueError:
@@ -90,7 +90,7 @@ class BasePayment(models.Model):
         available_statuses = [choice[0] for choice in FraudStatus.CHOICES]
         if status not in available_statuses:
             raise ValueError(
-                'Wrong status "%s", it should be one of: %s' % (
+                'Wrong status "{}", it should be one of: {}'.format(
                     status, ', '.join(available_statuses)))
         self.fraud_status = status
         self.fraud_message = message
@@ -110,7 +110,7 @@ class BasePayment(models.Model):
                         break
                 tries.add(token)
 
-        return super(BasePayment, self).save(**kwargs)
+        return super().save(**kwargs)
 
     def __unicode__(self):
         return self.variant

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -63,7 +63,7 @@ class PaypalProvider(BasicProvider):
         self.payment_execute_url = self.payments_url + '/%(id)s/execute/'
         self.payment_refund_url = (
             self.endpoint + '/v1/payments/capture/{captureId}/refund')
-        super(PaypalProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def set_response_data(self, payment, response, is_auth=False):
         extra_data = json.loads(payment.extra_data or '{}')
@@ -72,8 +72,8 @@ class PaypalProvider(BasicProvider):
         else:
             extra_data['response'] = response
             if 'links' in response:
-                extra_data['links'] = dict(
-                    (link['rel'], link) for link in response['links'])
+                extra_data['links'] = {
+                    link['rel']: link for link in response['links']}
         payment.extra_data = json.dumps(extra_data)
 
     def set_response_links(self, payment, response):
@@ -82,7 +82,7 @@ class PaypalProvider(BasicProvider):
         resource_key = 'sale' if self._capture else 'authorization'
         links = related_resources[resource_key]['links']
         extra_data = json.loads(payment.extra_data or '{}')
-        extra_data['links'] = dict((link['rel'], link) for link in links)
+        extra_data['links'] = {link['rel']: link for link in links}
         payment.extra_data = json.dumps(extra_data)
 
     def set_error_data(self, payment, error):
@@ -140,7 +140,7 @@ class PaypalProvider(BasicProvider):
                 'expires_in' in last_auth_response and
                 (created + timedelta(
                     seconds=last_auth_response['expires_in'])) > now):
-            return '%s %s' % (last_auth_response['token_type'],
+            return '{} {}'.format(last_auth_response['token_type'],
                               last_auth_response['access_token'])
         else:
             headers = {'Accept': 'application/json',
@@ -153,7 +153,7 @@ class PaypalProvider(BasicProvider):
             data = response.json()
             last_auth_response.update(data)
             self.set_response_data(payment, last_auth_response, is_auth=True)
-            return '%s %s' % (data['token_type'], data['access_token'])
+            return '{} {}'.format(data['token_type'], data['access_token'])
 
     def get_transactions_items(self, payment):
         for purchased_item in payment.get_purchased_items():

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -1,11 +1,6 @@
-from __future__ import unicode_literals
 from datetime import timedelta
 from decimal import Decimal, ROUND_HALF_UP
 from functools import wraps
-try:
-    from itertools import ifilter as filter
-except ImportError:
-    pass
 import json
 import logging
 

--- a/payments/paypal/forms.py
+++ b/payments/paypal/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from requests.exceptions import HTTPError
 
 from ..forms import CreditCardPaymentFormWithName

--- a/payments/paypal/forms.py
+++ b/payments/paypal/forms.py
@@ -10,7 +10,7 @@ class PaymentForm(CreditCardPaymentFormWithName):
     VALID_TYPES = ['visa', 'mastercard', 'discover', 'amex']
 
     def clean(self):
-        cleaned_data = super(PaymentForm, self).clean()
+        cleaned_data = super().clean()
 
         if not self.errors:
             if not self.payment.transaction_id:

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -1,8 +1,7 @@
-from __future__ import unicode_literals
 import json
 from decimal import Decimal
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from django.utils import timezone
 from requests import HTTPError

--- a/payments/sagepay/__init__.py
+++ b/payments/sagepay/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import binascii
 
 from cryptography.hazmat.primitives import padding

--- a/payments/sagepay/__init__.py
+++ b/payments/sagepay/__init__.py
@@ -28,7 +28,7 @@ class SagepayProvider(BasicProvider):
         self._vendor = vendor
         self._enckey = encryption_key.encode('utf-8')
         self._action = endpoint
-        super(SagepayProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Sagepay does not support pre-authorization.')
@@ -61,9 +61,9 @@ class SagepayProvider(BasicProvider):
         return_url = self.get_return_url(payment)
         data = {
             'VendorTxCode': payment.pk,
-            'Amount': "%.2f" % (payment.total,),
+            'Amount': "{:.2f}".format(payment.total),
             'Currency': payment.currency,
-            'Description': "Payment #%s" % (payment.pk,),
+            'Description': "Payment #{}".format(payment.pk),
             'SuccessURL': return_url,
             'FailureURL': return_url,
             'BillingSurname': payment.billing_last_name,

--- a/payments/sagepay/test_sagepay.py
+++ b/payments/sagepay/test_sagepay.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 
 from . import SagepayProvider
 from .. import PaymentStatus

--- a/payments/sagepay/test_sagepay.py
+++ b/payments/sagepay/test_sagepay.py
@@ -42,7 +42,7 @@ class TestSagepayProvider(TestCase):
     @patch('payments.sagepay.redirect')
     def test_provider_raises_redirect_needed_on_success(self, mocked_redirect):
         data = {'Status': 'OK'}
-        data = "&".join(u"%s=%s" % kv for kv in data.items())
+        data = "&".join("%s=%s" % kv for kv in data.items())
         with patch.object(SagepayProvider, 'aes_dec', return_value=data):
             self.provider.process_data(self.payment, MagicMock())
             self.assertEqual(self.payment.status, PaymentStatus.CONFIRMED)
@@ -51,7 +51,7 @@ class TestSagepayProvider(TestCase):
     @patch('payments.sagepay.redirect')
     def test_provider_raises_redirect_needed_on_failure(self, mocked_redirect):
         data = {'Status': ''}
-        data = "&".join(u"%s=%s" % kv for kv in data.items())
+        data = "&".join("%s=%s" % kv for kv in data.items())
         with patch.object(SagepayProvider, 'aes_dec', return_value=data):
             self.provider.process_data(self.payment, MagicMock())
             self.assertEqual(self.payment.status, PaymentStatus.REJECTED)

--- a/payments/sofort/__init__.py
+++ b/payments/sofort/__init__.py
@@ -19,7 +19,7 @@ class SofortProvider(BasicProvider):
         self.project_id = kwargs.pop('project_id')
         self.endpoint = kwargs.pop(
              'endpoint', 'https://api.sofort.com/api/xml')
-        super(SofortProvider, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
     
     def post_request(self, xml_request):
         response = requests.post(
@@ -50,7 +50,7 @@ class SofortProvider(BasicProvider):
                 raise RedirectNeeded(doc['new_transaction']['payment_url'])
             except KeyError:
                 raise PaymentError(
-                    'Error in %s: %s' % (
+                    'Error in {}: {}'.format(
                         doc['errors']['error']['field'],
                         doc['errors']['error']['message']))
 

--- a/payments/sofort/test_sofort.py
+++ b/payments/sofort/test_sofort.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 from unittest import TestCase
-from mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock
 import json
 
 from . import SofortProvider

--- a/payments/stripe/__init__.py
+++ b/payments/stripe/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from decimal import Decimal
 import json
 

--- a/payments/stripe/__init__.py
+++ b/payments/stripe/__init__.py
@@ -18,7 +18,7 @@ class StripeProvider(BasicProvider):
         self.public_key = public_key
         self.image = image
         self.name = name
-        super(StripeProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def get_form(self, payment, data=None):
         if payment.status == PaymentStatus.WAITING:

--- a/payments/stripe/forms.py
+++ b/payments/stripe/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 import stripe
 from django import forms

--- a/payments/stripe/forms.py
+++ b/payments/stripe/forms.py
@@ -11,7 +11,7 @@ from ..widgets import (
 from .widgets import StripeCheckoutWidget, StripeWidget
 
 
-class StripeFormMixin(object):
+class StripeFormMixin:
 
     charge = None
 
@@ -34,7 +34,7 @@ class StripeFormMixin(object):
                         "amount": int(self.payment.total * 100),
                         "currency": self.payment.currency,
                         "card": data['stripeToken'],
-                        "description": '%s %s' % (
+                        "description": '{} {}'.format(
                             self.payment.billing_last_name,
                             self.payment.billing_first_name
                         ),
@@ -90,7 +90,7 @@ class PaymentForm(StripeFormMixin, CreditCardPaymentFormWithName):
     stripeToken = forms.CharField(widget=StripeWidget())
 
     def __init__(self, *args, **kwargs):
-        super(PaymentForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         stripe_attrs = self.fields['stripeToken'].widget.attrs
         stripe_attrs['data-publishable-key'] = self.provider.public_key
         stripe_attrs['data-address-line1'] = self.payment.billing_address_1

--- a/payments/stripe/test_stripe.py
+++ b/payments/stripe/test_stripe.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from contextlib import contextmanager
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from unittest import TestCase
 import stripe
 

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -22,7 +22,7 @@ class StripeCheckoutWidget(Input):
             'data-currency': payment.currency
         }
         kwargs['attrs'].update(attrs)
-        super(StripeCheckoutWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):
         if value is None:
@@ -44,4 +44,4 @@ class StripeWidget(HiddenInput):
 
     def __init__(self, attrs=None):
         attrs = dict(attrs or {}, id='id_stripe_token')
-        super(StripeWidget, self).__init__(attrs)
+        super().__init__(attrs)

--- a/payments/stripe/widgets.py
+++ b/payments/stripe/widgets.py
@@ -1,12 +1,7 @@
-from __future__ import unicode_literals
-
-try:
-    from django.forms.utils import flatatt
-except ImportError:
-    from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms.widgets import Input, HiddenInput
-from django.utils.html import format_html
 from django.utils.encoding import force_text
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -1,7 +1,6 @@
-from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
-from mock import patch, NonCallableMock
+from unittest.mock import patch, NonCallableMock
 
 from payments import core
 from .forms import CreditCardPaymentFormWithName, PaymentForm

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -2,17 +2,11 @@
 This module is responsible for automatic processing of provider callback
 data (asynchronous transaction updates).
 '''
-from __future__ import unicode_literals
-
-from django.conf.urls import url
+from django.db.transaction import atomic
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
-try:
-    from django.db.transaction import atomic
-except ImportError:
-    def atomic(func):
-        return func
 
 from . import get_payment_model
 from .core import provider_factory
@@ -52,8 +46,8 @@ def static_callback(request, variant):
 
 
 urlpatterns = [
-    url(r'^process/(?P<token>[0-9a-z]{8}-[0-9a-z]{4}-'
-        '[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})/$', process_data,
-        name='process_payment'),
-    url(r'^process/(?P<variant>[a-z-]+)/$', static_callback,
-        name='static_process_payment')]
+    re_path(r'^process/(?P<token>[0-9a-z]{8}-[0-9a-z]{4}-'
+            '[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})/$', process_data,
+            name='process_payment'),
+    re_path(r'^process/(?P<variant>[a-z-]+)/$', static_callback,
+            name='static_process_payment')]

--- a/payments/wallet/__init__.py
+++ b/payments/wallet/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import time
 
 from django.core.exceptions import ImproperlyConfigured

--- a/payments/wallet/__init__.py
+++ b/payments/wallet/__init__.py
@@ -16,7 +16,7 @@ class GoogleWalletProvider(BasicProvider):
         self.seller_id = seller_id
         self.seller_secret = seller_secret
         self.library = library
-        super(GoogleWalletProvider, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not self._capture:
             raise ImproperlyConfigured(
                 'Google Wallet does not support pre-authorization.')

--- a/payments/wallet/forms.py
+++ b/payments/wallet/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 import jwt
 

--- a/payments/wallet/forms.py
+++ b/payments/wallet/forms.py
@@ -9,7 +9,7 @@ from .widgets import WalletWidget
 class PaymentForm(BasePaymentForm):
 
     def __init__(self, *args, **kwargs):
-        super(PaymentForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         widget = WalletWidget(provider=self.provider, payment=self.payment)
         self.fields['payment'] = forms.CharField(widget=widget, required=False)
 
@@ -19,12 +19,12 @@ class ProcessPaymentForm(forms.Form):
     jwt = forms.CharField(required=True)
 
     def __init__(self, payment, provider, **kwargs):
-        super(ProcessPaymentForm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.provider = provider
         self.payment = payment
 
     def clean_jwt(self):
-        payload = super(ProcessPaymentForm, self).clean().get('jwt')
+        payload = super().clean().get('jwt')
         try:
             jwt_data = jwt.decode(
                 payload.encode('utf-8'), self.provider.seller_secret,

--- a/payments/wallet/test_wallet.py
+++ b/payments/wallet/test_wallet.py
@@ -1,11 +1,10 @@
-from __future__ import unicode_literals
 import time
 from decimal import Decimal
 from unittest import TestCase
 
 from django.http import HttpResponse, HttpResponseForbidden
 import jwt
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from .. import PaymentStatus
 from . import GoogleWalletProvider

--- a/payments/wallet/test_wallet.py
+++ b/payments/wallet/test_wallet.py
@@ -30,7 +30,7 @@ JWT_DATA = {
         'orderId': '1234567890'}}
 
 
-class Payment(object):
+class Payment:
 
     id = 1
     description = 'payment'

--- a/payments/wallet/widgets.py
+++ b/payments/wallet/widgets.py
@@ -11,12 +11,12 @@ class WalletWidget(HiddenInput):
             'data-success-url': payment.get_success_url(),
             'data-failure-url': payment.get_failure_url(),
         }
-        super(WalletWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.js = [provider.library, 'js/payments/wallet.js']
 
     @property
     def media(self):
-        media = super(WalletWidget, self).media
+        media = super().media
         try:  # Django < 2.2
             media._js = self.js
         except AttributeError:

--- a/payments/wallet/widgets.py
+++ b/payments/wallet/widgets.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.forms.widgets import HiddenInput
 
 

--- a/payments/widgets.py
+++ b/payments/widgets.py
@@ -7,7 +7,7 @@ class CreditCardNumberWidget(TextInput):
 
     def render(self, name, value, attrs=None, renderer=None):
         if value:
-            value = re.sub('[\s-]', '', value)
+            value = re.sub(r'[\s-]', '', value)
             if len(value) == 16:
                 value = ' '.join([value[0:4], value[4:8],
                                   value[8:12], value[12:16]])
@@ -15,7 +15,7 @@ class CreditCardNumberWidget(TextInput):
                 value = ' '.join([value[0:4], value[4:10], value[10:15]])
             elif len(value) == 14:
                 value = ' '.join([value[0:4], value[4:10], value[10:14]])
-        return super(CreditCardNumberWidget, self).render(name, value, attrs)
+        return super().render(name, value, attrs)
 
 
 # Credit Card Expiry Fields from:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ PACKAGES = [
 
 REQUIREMENTS = [
     'braintree>=3.14.0',
-    'Django>=1.11',
+    'Django>=2.2',
     'cryptography>=1.1.0',
     'PyJWT>=1.3.0',
     'requests>=1.2.0',
@@ -67,8 +67,6 @@ setup(
     include_package_data=True,
     classifiers=[
         'Environment :: Web Environment',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
@@ -76,7 +74,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -89,7 +86,6 @@ setup(
     cmdclass={
         'test': PyTest},
     tests_require=[
-        'mock',
         'pytest',
         'pytest-django'],
     zip_safe=False)

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 
 PROJECT_ROOT = os.path.normpath(

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27-django111, py{35,36,37,38}-django{111,21,22,30,31,_master}
+envlist = py{35,36,37,38}-django{22,30,31,_master}
 
 [testenv]
 usedevelop=True
 deps=
     coverage
-    django111: django>=1.11a1,<1.12
-    django21: Django>=2.1a1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
@@ -22,7 +20,6 @@ DJANGO_SETTINGS_MODULE = test_settings
 
 [travis]
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37
@@ -31,8 +28,6 @@ unignore_outcomes = True
 
 [travis:env]
 DJANGO =
-    1.11: django111
-    2.1: django21
     2.2: django22
     3.0: django30
     3.1: django31


### PR DESCRIPTION
Drop support for versions for Python and Django that are not longer supported by upstream.

There's no point in supporting this anymore, and lots of small cleanups that can be done. Users of older Python or Django versions can continue using the latest stable release.

I wonder if it would make sense to push a major version when this gets released.

I'll try to address django-master too, since there's some upcoming breaking changes for tests: `TypeError: Abstract models cannot be instantiated`.